### PR TITLE
close #5 Dev Containers 環境でのコンパイルをできるようにする

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "TeX Live Japanese Development Container",
+  "dockerComposeFile": ["../compose.yaml"],
+  "service": "latex",
+  "workspaceFolder": "/workspace",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "James-Yu.latex-workshop"
+      ]
+    }
+  }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,14 +11,25 @@ RUN apt-get update && \
     make \
     inotify-tools \
     procps \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    locales && \
+    # ロケールの生成と設定
+    sed -i -E 's/# (ja_JP.UTF-8)/\1/' /etc/locale.gen && \
+    locale-gen && \
+    # ロケールの設定
+    update-locale LANG=ja_JP.UTF-8 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # TeXLive パッケージのインストール
 RUN tlmgr update --self && \
     tlmgr install \
     algorithms \
     algorithmicx
+
+# ロケール設定
+ENV LANG=ja_JP.UTF-8
+ENV LANGUAGE=ja_JP:ja
+ENV LC_ALL=ja_JP.UTF-8
 
 # 作業ディレクトリの設定
 WORKDIR /workspace

--- a/README.md
+++ b/README.md
@@ -2,42 +2,52 @@
 
 このリポジトリは、Docker を使用した日本語 LaTeX 執筆環境を提供するリポジトリである。
 
-## クイックスタート
+## 環境構築
 
-### Makefile を使用した make コマンド
+### 1. Makefile を使用した環境構築
+
+`make` コマンドが利用可能な環境では、すぐに以下の手順で環境を構築できる：
 
 ```bash
 # 初回セットアップ（Docker イメージのビルドと起動）
 make setup
 
-# TeXファイルのコンパイル（src/*.tex のすべてのファイル）
-make compile
+# src 下の .tex ファイルをコンパイルし、PDF に変換
+make
 
-# src/ 下のすべての .tex ファイルを監視し、変更があったら自動コンパイル、PDF 出力
-make watch
-
-# 生成されたPDFを確認 (Mac のみ)
-make open-pdf
+# 最新の .tex ファイルの内容をコピーし、現在の日付で新規 .tex ファイルを作成
+# 変更を自動監視し、変更後の内容で PDF を再生成
+make copy
 ```
 
-## 環境構築
+`make copy` 実行後は、新規作成した .tex ファイルの変更を監視する。
 
-### 1. Docker コンテナのビルドと起動
+生成された PDF ファイルは `pdf/` ディレクトリに出力される。
+
+### 2. Dev Containers を使用した環境構築
+
+VS Code の Dev Containers を使用して環境を構築することもできる：
+
+1. VS Code に [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) 拡張機能をインストールする。
+2. このリポジトリを VS Code で開く。
+3. コマンドパレット（`Cmd + Shift + P または Ctrl + Shift + P`）を開き、`Dev Containers: Rebuild and Reopen in Container` を選択する。もしくは、GUI 左下の青い >< から、`コンテナーで再度開く` -> `ワークスペースに構成を追加する` -> `` `Dockerfile` から`` -> 青い OK ボタン -> 青い OK ボタン の順で選択する。
+4. コンテナ内で以下のコマンドを使用して作業を進める：
+
+これにより、Docker コンテナ内で `make` を実行可能となり、以下の手順で環境を構築できる：
 
 ```bash
-# 初回セットアップ (推奨)
-make setup
+# src 下の .tex ファイルをコンパイルし、PDF に変換
+make
 
-# または個別に実行
-make build  # Dockerイメージをビルド
-make up     # コンテナを起動
+# 最新の .tex ファイルの内容をコピーし、現在の日付で新規 .tex ファイルを作成
+# 変更を自動監視し、変更後の内容で PDF を再生成
+make copy
 ```
+Dev Container 環境下では Docker 関連のコマンドの操作は不要。
 
-### 2. コンテナへの接続 (必要な場合)
+`make copy` 実行後は、新規作成した .tex ファイルの変更を監視する。
 
-```bash
-make exec
-```
+生成された PDF ファイルは `pdf/` ディレクトリに出力される。
 
 ## LaTeX文書の作成とコンパイル
 
@@ -66,22 +76,32 @@ make watch
 
 ## 利用可能なMakeコマンド
 
-| コマンド | 説明 |
-|---------|------|
-| `make help` | 利用可能なコマンド一覧を表示 |
-| `make setup` | 初回セットアップ (ビルド + 起動) |
-| `make build` | Dockerイメージをビルド |
-| `make up` | コンテナを起動 |
-| `make down` | コンテナを停止・削除 |
-| `make exec` | コンテナに接続 |
-| `make compile` | src/ 下の TeX ファイルを強制再コンパイル |
-| `make watch` | src /下の TeX ファイルの変更を監視してコンパイル |
-| `make clean` | LaTeX 中間ファイルを削除 |
+### LaTeX 関連コマンド
+
+| コマンド          | 説明                                                         |
+|------------------|-------------------------------------------------------------|
+| `make help`      | 利用可能なコマンド一覧を表示 |
+| `make compile`   | `src` 下の TeX ファイルを強制再コンパイル |
+| `make watch`     | ファイルの変更を監視してコンパイル |
+| `make copy`      | 今日の日付で新しい `.tex` ファイルを作成。変更を監視し、自動コンパイル |
+| `make clean`     | LaTeX 中間ファイルを削除 |
 | `make clean-all` | すべての LaTeX 生成ファイルを削除 |
-| `make open-pdf` | 生成された PDF を開く (Mac用) |
-| `make restart` | コンテナを再起動 |
-| `make rebuild` | 完全に再ビルド |
-| `make dev` | 開発モード (起動 + 監視コンパイル) |
+| `make open-pdf`  | 生成された PDF を開く (Mac用) |
+
+### Docker 関連コマンド
+
+| コマンド          | 説明                          |
+|------------------|------------------------------|
+| `make setup`     | 初回セットアップ (ビルド + 起動) |
+| `make build`     | Docker イメージをビルド |
+| `make up`        | コンテナを起動 |
+| `make down`      | コンテナを停止・削除 |
+| `make exec`      | コンテナに接続 |
+| `make stop`      | コンテナを停止 |
+| `make logs`      | コンテナのログを表示 |
+| `make restart`   | コンテナを再起動 |
+| `make rebuild`   | 完全に再ビルド |
+| `make dev`       | 開発モード (起動 + 監視コンパイル) |
 
 ## ディレクトリ構成
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ texlive-ja-template/
 ## 使用できる TeXLive パッケージ
 
 - latexmk: 自動コンパイルツール
+- algorythm, algorithmicx: アルゴリズム
 
 ## 不具合対処
 


### PR DESCRIPTION
make 環境がない場合、make setup による初回セットアップができなかった。
そのため、Dev Container で Docker コンテナ内で動作できるようにした。

これにより、Dockerfile で make パッケージをインストールするようにしているため、各 make コマンドが実行できるようになる。
make build など、一部の docker コマンドを用いる make コマンドは、Dev Container 環境では実行できない。
そのため、docker コマンドを用いる make コマンドを実行した場合は、そのコマンドが実行できない・実行不要であることを示すメッセージを表示する。