### PR TITLE
close #7 make watch 実行中にファイル保存をしても PDF が再生成されない問題の修正 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,17 +24,19 @@ LATEX_CLEAN = $(DOCKER_PREFIX) $(CD_PREFIX) latexmk -c
 LATEX_CLEAN_ALL = $(DOCKER_PREFIX) $(CD_PREFIX) latexmk -C
 CP_CMD = $(DOCKER_PREFIX) $(CD_PREFIX) cp
 RM_CMD = $(DOCKER_PREFIX) $(CD_PREFIX) rm -rf
-WATCH_CMD = $(DOCKER_PREFIX) bash -c '\
-    cd /workspace && \
+WATCH_CMD = $(DOCKER_PREFIX) bash -c 'cd /workspace && \
     while true; do \
-        changed_file=$$(inotifywait -e close_write,create --format "%w%f" src/*.tex); \
-        if [ -f "$$changed_file" ]; then \
-            echo "Compiling: $$changed_file"; \
-            TEXINPUTS=./src//: latexmk -pdfdvi "$$changed_file" && \
-            cp build/$$(basename "$$changed_file" .tex).pdf pdf/; \
-        fi; \
-    done \
-'
+        inotifywait -r -e modify,create,delete src/*.tex; \
+        echo "Changes detected, recompiling..."; \
+        for tex in src/*.tex; do \
+            if [ -f "$$tex" ]; then \
+                echo "Compiling: $$tex"; \
+                TEXINPUTS=./src//: latexmk -pdfdvi "$$tex" && \
+                mkdir -p pdf && \
+                cp build/$$(basename "$$tex" .tex).pdf pdf/ || echo "Failed to copy PDF for $$tex"; \
+            fi \
+        done; \
+    done'
 LATEX_SINGLE = $(LATEX_CMD)
 
 # デフォルトターゲット

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,13 @@ LATEX_SINGLE = $(LATEX_CMD)
 
 # デフォルトターゲット
 all: $(PDF_FILES) ## すべての TeX ファイルを PDF に変換
+	@if [ -n "$(TEX_FILES)" ]; then \
+		echo "コンパイル完了、ファイルの変更監視を開始"; \
+		make watch; \
+	else \
+		echo "[WARNING] src/ ディレクトリに .tex ファイルが見つかりません。"; \
+		exit 1; \
+	fi
 
 help: ## ヘルプを表示
 	@echo "利用可能なコマンド:"
@@ -60,6 +67,8 @@ compile: ## src 下の .tex ファイルをコンパイル
 		$(LATEX_CMD) $$tex; \
 		$(CP_CMD) build/$$(basename $${tex%.tex}).pdf pdf/; \
 	done
+	@echo "コンパイル完了、ファイルの変更監視を開始"
+	@make watch
 
 watch: ## ファイル変更を監視してコンパイル
 	@mkdir -p pdf build


### PR DESCRIPTION
# 概要
make watch 実行中にもかかわらず、.tex ファイルに変更を加えて保存をしても、PDF が再生成されない問題を修正。

さらに、 make コマンドと make compile 実行時、自動で make watch コマンドを実行するように。
これにより、make watch を打たなくとも、コンパイル系のコマンドを実行すると、自動でファイル変更を監視できるようになる。

# 環境 (Dev Container or Docker compose)

- [x] Dev Container
- [x] Docker compose
