### PR TITLE
close #11 IPSJ 環境でのビルドとPDF出力

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ build/
 # IDE
 .vscode/
 .idea/
+.make.pid

--- a/README.md
+++ b/README.md
@@ -1,26 +1,50 @@
 # 日本語 LaTeX 執筆環境 (Docker)
 
 このリポジトリは、Docker を使用した日本語 LaTeX 執筆環境を提供するリポジトリである。
+標準的な LaTeX 文書に加え、情報処理学会 (IPSJ) 論文形式にも対応している。
+
+## IPSJ 論文形式への対応
+
+本環境では、IPSJ が配布するテンプレートファイル一式（`ipsj.cls`、`.bst`、`.sty` など）を `src/IPSJ/` 以下のサブディレクトリにそのまま配置することで、**IPSJ 指定の環境で PDF を作成できる**。
+
+具体的には、[情報処理学会 LaTeX スタイルファイル](https://www.ipsj.or.jp/journal/submit/style.html) から入手したテンプレートフォルダの中身を、エンコーディングに応じて以下のディレクトリにコピーする：
+
+```
+src/IPSJ/
+├── UTF8/          # UTF-8 エンコーディング用（推奨）
+│   ├── .latexmkrc     # IPSJ 用コンパイル設定
+│   ├── ipsj.cls       # IPSJ クラスファイル
+│   ├── ipsjpref.sty   # IPSJ スタイルファイル
+│   ├── ipsjtech.sty
+│   ├── *.bst          # 参考文献スタイル (ipsjsort.bst, ipsjunsrt.bst 等)
+│   ├── *.bib          # 参考文献データ
+│   ├── images/        # 図版ディレクトリ
+│   └── your-paper.tex # 自分の論文ファイル
+└── SJIS/          # Shift-JIS エンコーディング用
+    ├── .latexmkrc
+    ├── ipsj.cls
+    └── ...（同様の構成）
+```
+
+テンプレートファイルをディレクトリごと配置することで、以下が可能になる：
+
+- **IPSJ 指定環境での PDF 生成**: `ipsj.cls` や各種 `.bst` ファイルが同一ディレクトリにあるため、IPSJ のフォーマットに準拠した PDF を `make` コマンド一つで生成できる
+- **句読点の自動変換**: IPSJ 論文で求められるカンマ・ピリオド表記（「、」→「，」、「。」→「．」）への変換を `make convert-punctuation` で一括実行できる
+- **参考文献の処理**: pBibTeX による参考文献処理と、参照番号の解決のための多重コンパイルを自動で行う
 
 ## 環境構築
 
 ### 1. Makefile を使用した環境構築
 
-`make` コマンドが利用可能な環境では、すぐに以下の手順で環境を構築できる：
+`make` コマンドが利用可能な環境では、以下の手順で環境を構築できる：
 
 ```bash
 # 初回セットアップ（Docker イメージのビルドと起動）
 make setup
 
-# src 下の .tex ファイルをコンパイルし、PDF に変換
+# src 下の .tex ファイルをコンパイルし、PDF に変換。その後、変更を自動監視
 make
-
-# 最新の .tex ファイルの内容をコピーし、現在の日付で新規 .tex ファイルを作成
-# 変更を自動監視し、変更後の内容で PDF を再生成
-make copy
 ```
-
-`make copy` 実行後は、新規作成した .tex ファイルの変更を監視する。
 
 生成された PDF ファイルは `pdf/` ディレクトリに出力される。
 
@@ -33,49 +57,57 @@ VS Code の Dev Containers を使用して環境を構築することもでき�
 3. コマンドパレット（`Cmd + Shift + P または Ctrl + Shift + P`）を開き、`Dev Containers: Rebuild and Reopen in Container` を選択する。もしくは、GUI 左下の青い >< から、`コンテナーで再度開く` -> `ワークスペースに構成を追加する` -> `` `Dockerfile` から`` -> 青い OK ボタン -> 青い OK ボタン の順で選択する。
 4. コンテナ内で以下のコマンドを使用して作業を進める：
 
-これにより、Docker コンテナ内で `make` を実行可能となり、以下の手順で環境を構築できる：
-
 ```bash
-# src 下の .tex ファイルをコンパイルし、PDF に変換
+# src 下の .tex ファイルをコンパイルし、PDF に変換。その後、変更を自動監視
 make
 
-# 最新の .tex ファイルの内容をコピーし、現在の日付で新規 .tex ファイルを作成
-# 変更を自動監視し、変更後の内容で PDF を再生成
-make copy
+# ファイルの変更を監視してコンパイル（監視のみ）
+make watch
 ```
-Dev Container 環境下では Docker 関連のコマンドの操作は不要。
 
-`make copy` 実行後は、新規作成した .tex ファイルの変更を監視する。
+Dev Container 環境下では Docker 関連のコマンドの操作は不要。
 
 生成された PDF ファイルは `pdf/` ディレクトリに出力される。
 
-## LaTeX文書の作成とコンパイル
+## LaTeX 文書の作成とコンパイル
 
-### 1. TeXファイルの配置
+### 1. TeX ファイルの配置
 
-#### 標準的なLaTeX文書
+#### 標準的な LaTeX 文書
+
+`src/` ディレクトリ直下に `.tex` ファイルを配置する：
+
 ```
 src/
 ├── sample.tex
 └── other.tex
 ```
 
-#### IPSJ論文形式
-IPSJ論文の場合は、エンコーディングに応じたサブディレクトリに配置：
+#### IPSJ 論文形式
+
+IPSJ 論文の場合は、IPSJ から配布されるテンプレートファイル一式をエンコーディングに応じたサブディレクトリに配置する。テンプレートは [情報処理学会 LaTeX スタイルファイル](https://www.ipsj.or.jp/journal/submit/style.html) から入手できる。
+
+**重要**: `ipsj.cls` や `.bst` ファイルなど、テンプレートに含まれるファイルをすべて同一ディレクトリに配置すること。これにより、IPSJ のスタイル定義やコンパイル設定がそのまま利用でき、IPSJ 指定のフォーマットで PDF が生成される。
+
 ```
 src/IPSJ/
-├── UTF8/              # UTF-8エンコーディング（推奨）
-│   └── paper.tex
-└── SJIS/              # Shift-JISエンコーディング
-    └── paper.tex
+├── UTF8/                  # UTF-8 エンコーディング（推奨）
+│   ├── .latexmkrc         # コンパイル設定（同梱済み）
+│   ├── ipsj.cls           # クラスファイル（テンプレートからコピー）
+│   ├── ipsjpref.sty       # スタイルファイル（テンプレートからコピー）
+│   ├── ipsjsort.bst       # 参考文献スタイル（テンプレートからコピー）
+│   ├── ipsjunsrt.bst
+│   ├── your-paper.tex     # 自分の論文
+│   ├── your-paper.bib     # 参考文献データ
+│   └── images/            # 図版
+└── SJIS/                  # Shift-JIS エンコーディング
+    └── ...（同様の構成）
 ```
-
-他にも必要なファイルが複数存在するため、各自のリンクもしくは [情報処理学会, LaTeXスタイルファイル、MS-Wordテンプレートファイル](https://www.ipsj.or.jp/journal/submit/style.html) からテンプレートのフォルダを入手し、ファイルを各ディレクトリへコピーすること。
 
 ### 2. コンパイル方法
 
 ```bash
-# src/ 下のすべての .tex ファイルの変更分をコンパイル
+# src/ 下のすべての .tex ファイルの変更分をコンパイルし、監視開始
 make
 
 # src/ 下のすべての .tex ファイルを強制的に再コンパイル
@@ -85,35 +117,36 @@ make compile
 make watch
 ```
 
-生成されたPDFファイルは `pdf/` ディレクトリにサブディレクトリ構造を保持して出力される。
+生成された PDF ファイルは `pdf/` ディレクトリにサブディレクトリ構造を保持して出力される。
+例: `src/IPSJ/UTF8/paper.tex` → `pdf/IPSJ/UTF8/paper.pdf`
 
-## 利用可能なMakeコマンド
+## 利用可能な Make コマンド
 
 ### LaTeX 関連コマンド
 
 | コマンド          | 説明                                                         |
 |------------------|-------------------------------------------------------------|
+| `make`           | すべての TeX ファイルを PDF に変換し、変更の自動監視を開始 |
 | `make help`      | 利用可能なコマンド一覧を表示 |
 | `make compile`   | `src` 下の TeX ファイルを強制再コンパイル |
 | `make watch`     | ファイルの変更を監視してコンパイル |
-| `make copy`      | 今日の日付で新しい `.tex` ファイルを作成。変更を監視し、自動コンパイル |
 | `make clean`     | LaTeX 中間ファイルを削除 |
 | `make clean-all` | すべての LaTeX 生成ファイルを削除 |
-| `make open-pdf`  | 生成された PDF を開く (Mac用) |
+| `make open-pdf`  | 生成された PDF を開く (Mac 用) |
 
-### IPSJ論文専用コマンド
+### IPSJ 論文専用コマンド
 
 | コマンド          | 説明                                                         |
 |------------------|-------------------------------------------------------------|
-| `make convert-punctuation FILE=path/to/file.tex` | 指定したIPSJファイルの句読点を変換（、→，、。→．） |
-| `make restore-punctuation FILE=path/to/file.tex` | 変換前の句読点に戻す |
+| `make convert-punctuation FILE=<path>` | 指定した IPSJ ファイルの句読点をカンマ・ピリオドに変換（「、」→「，」、「。」→「．」） |
+| `make restore-punctuation FILE=<path>` | 変換前の句読点に戻す |
 
 **使用例:**
 ```bash
-# 句読点変換
+# 句読点変換（IPSJ 投稿規定に合わせる）
 make convert-punctuation FILE=src/IPSJ/UTF8/paper.tex
 
-# 句読点復元
+# 句読点復元（元の表記に戻す）
 make restore-punctuation FILE=src/IPSJ/UTF8/paper.tex
 ```
 
@@ -138,47 +171,48 @@ make restore-punctuation FILE=src/IPSJ/UTF8/paper.tex
 texlive-ja-template/
 ├── Dockerfile          # Docker 環境定義
 ├── compose.yaml        # Docker Compose 設定
-├── Makefile           # ビルドタスク定義
-├── .latexmkrc         # LaTeXmk 設定
-├── scripts/           # ビルドスクリプト
-│   └── watch.sh       # ファイル監視スクリプト
-├── build/             # コンパイル中間ファイル
-│   └── *.aux, *.dvi など
-├── pdf/               # 生成されたPDF
-│   └── *.pdf
-└── src/               # TeX ソースファイル
-    ├── *.tex          # 標準的なLaTeXファイル
-    └── IPSJ/          # IPSJ論文形式
-        ├── UTF8/      # UTF-8エンコーディング用
-        │   ├── .latexmkrc # 2025年8月現在のもの、コンパイルオプション等に変更があれば編集必須
-        │   ├── ipsj.cls   # クラスファイル、テンプレートファイルからコピーして配置
-        │   └── *.tex
-        └── SJIS/      # Shift-JISエンコーディング用
-            ├── .latexmkrc
-            ├── ipsj.cls
-            └── *.tex
+├── Makefile            # ビルドタスク定義
+├── .latexmkrc          # LaTeXmk 設定（標準 LaTeX 用）
+├── scripts/            # ビルドスクリプト
+│   ├── watch.sh        # ファイル監視スクリプト
+│   └── full-compile.sh # IPSJ 用多重コンパイルスクリプト
+├── build/              # コンパイル中間ファイル
+├── image/              # 標準 LaTeX 用の画像ファイル
+├── pdf/                # 生成された PDF
+└── src/                # TeX ソースファイル
+    ├── *.tex           # 標準的な LaTeX ファイル
+    └── IPSJ/           # IPSJ 論文形式（テンプレートごと配置）
+        ├── UTF8/       # UTF-8 エンコーディング用
+        │   ├── .latexmkrc     # IPSJ 用コンパイル設定
+        │   ├── ipsj.cls       # クラスファイル
+        │   ├── *.sty          # スタイルファイル
+        │   ├── *.bst          # 参考文献スタイル
+        │   ├── *.tex          # 論文ファイル
+        │   └── images/        # 図版ディレクトリ
+        └── SJIS/       # Shift-JIS エンコーディング用
+            └── ...（UTF8 と同様の構成）
 ```
 
 ## 対応する論文形式とエンコーディング
 
-### 標準LaTeX
+### 標準 LaTeX
 - **エンコーディング**: UTF-8
 - **コンパイラ**: uplatex + dvipdfmx
 - **配置場所**: `src/*.tex`
 
-### IPSJ論文形式
+### IPSJ 論文形式
 - **エンコーディング**: UTF-8 または Shift-JIS
-- **コンパイラ**: uplatex + dvipdfmx
+- **コンパイラ**: platex + dvipdfmx（`full-compile.sh` による多重コンパイル）
 - **配置場所**:
-  - UTF-8: `src/IPSJ/UTF8/*.tex`
-  - SJIS: `src/IPSJ/SJIS/*.tex`
-- **クラスファイル**: 各ディレクトリに各自で配置する (2025/8 現在、ファイル名は ipsj.cls)
-- **句読点**: `make convert-punctuation` コマンドによる自動変換機能に対応（、→，、。→．）
+  - UTF-8: `src/IPSJ/UTF8/`（テンプレートファイル一式を含む）
+  - SJIS: `src/IPSJ/SJIS/`（テンプレートファイル一式を含む）
+- **クラスファイル**: IPSJ 配布のテンプレートから `ipsj.cls` を各ディレクトリに配置
+- **句読点変換**: `make convert-punctuation` による自動変換に対応（「、」→「，」、「。」→「．」）
 
 ## 使用できる TeXLive パッケージ
 
 - latexmk: 自動コンパイルツール
-- algorythm, algorithmicx: アルゴリズム
+- algorithms, algorithmicx: アルゴリズム記述
 - graphicx: 図版挿入
 - color: カラー対応
 
@@ -197,15 +231,15 @@ make clean-all  # すべての生成ファイルを削除
 make compile    # 再コンパイル
 ```
 
-3. **Docker環境の再構築**
+3. **Docker 環境の再構築**
 ```bash
 make rebuild    # コンテナの完全な再構築
 ```
 
-### IPSJ論文特有の問題
+### IPSJ 論文特有の問題
 
 1. **フォントエラーが発生する場合**
-   - IPSJクラスファイル(ipsj.cls)がipsj.clsの日本語フォント定義でエラーが発生することがありますが、デフォルトフォントで代替されるため問題ありません
+   - `ipsj.cls` の日本語フォント定義でエラーが発生することがあるが、デフォルトフォントで代替されるため問題ない
 
 2. **句読点の変換を間違えた場合**
 ```bash
@@ -214,7 +248,10 @@ make restore-punctuation FILE=src/IPSJ/UTF8/your-file.tex
 ```
 
 3. **エンコーディングエラーが発生する場合**
-   - UTF-8ファイルは `src/IPSJ/UTF8/` に配置
-   - Shift-JISファイルは `src/IPSJ/SJIS/` に配置
+   - UTF-8 ファイルは `src/IPSJ/UTF8/` に配置
+   - Shift-JIS ファイルは `src/IPSJ/SJIS/` に配置
    - ファイルのエンコーディングとディレクトリが一致していることを確認
-   - .tex ファイル内で使用するクラスファイルを確認
+
+4. **参考文献や図表の番号が表示されない場合**
+   - `make compile` で再コンパイルを実行する（多重コンパイルにより参照が解決される）
+   - `.bib` ファイルが論文ファイルと同じディレクトリに配置されているか確認する

--- a/scripts/full-compile.sh
+++ b/scripts/full-compile.sh
@@ -1,0 +1,196 @@
+#!/bin/bash
+set -euo pipefail
+
+# Full compilation script for LaTeX + BibTeX
+# Usage: ./full-compile.sh <tex-file-without-extension>
+#
+# This script performs a complete LaTeX compilation including:
+# - Multiple LaTeX passes for cross-references
+# - pBibTeX for bibliography processing
+# - DVI to PDF conversion
+
+# Logging functions
+log_info() {
+    echo "[INFO] $*"
+}
+
+log_warn() {
+    echo "[WARN] $*"
+}
+
+log_error() {
+    echo "[ERROR] $*" >&2
+}
+
+# Cleanup function
+cleanup_on_exit() {
+    local exit_code=$?
+    if [[ $exit_code -ne 0 ]]; then
+        log_error "Compilation failed with exit code $exit_code"
+    fi
+    exit $exit_code
+}
+
+trap cleanup_on_exit EXIT
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+    log_error "Invalid number of arguments"
+    echo "Usage: $0 <tex-file-without-extension> [encoding]"
+    echo "Example: $0 jsample UTF8"
+    echo "Example: $0 jsample SJIS"
+    echo "Encoding options: UTF8, SJIS (default: UTF8)"
+    exit 1
+fi
+
+TEX_BASE="$1"
+ENCODING="${2:-UTF8}"  # デフォルトはUTF8
+WORKSPACE="/workspace"
+
+# エンコーディング別の設定
+case "$ENCODING" in
+    "UTF8")
+        SOURCE_DIR="src/IPSJ/UTF8"
+        COMPILER="platex"
+        LANG_ENV="LANG=ja_JP.UTF-8 LC_ALL=ja_JP.UTF-8"
+        ;;
+    "SJIS")
+        SOURCE_DIR="src/IPSJ/SJIS"
+        COMPILER="platex"
+        LANG_ENV="LANG=ja_JP.SJIS LC_ALL=ja_JP.SJIS"
+        ;;
+    *)
+        log_error "Unsupported encoding: $ENCODING"
+        echo "Supported encodings: UTF8, SJIS"
+        exit 1
+        ;;
+esac
+
+# Check if we're inside Docker
+if [[ ! -f /.dockerenv ]]; then
+    log_error "This script must be run inside the Docker container"
+    exit 1
+fi
+
+cd "$WORKSPACE"
+
+log_info "=== Full compilation of $TEX_BASE (encoding: $ENCODING) ==="
+
+# Step 1: Clean all intermediate files
+log_info "Step 1: Cleaning intermediate files..."
+rm -f "build/${TEX_BASE}."* "${SOURCE_DIR}/${TEX_BASE}.aux" "${SOURCE_DIR}/${TEX_BASE}.bbl" 2>/dev/null || true
+
+# Step 2: First LaTeX compilation
+log_info "Step 2: First LaTeX compilation..."
+cd "$SOURCE_DIR"
+if ! eval "$LANG_ENV $COMPILER -output-directory=../../../build -interaction=nonstopmode '${TEX_BASE}.tex'" > /dev/null 2>&1; then
+    log_warn "First LaTeX compilation had warnings/errors (continuing)"
+fi
+
+# Check for cross-references and citations
+check_references() {
+    local aux_file="../../../build/${TEX_BASE}.aux"
+    local log_file="../../../build/${TEX_BASE}.log"
+
+    # Check for undefined references
+    if [[ -f "$log_file" ]] && grep -q "LaTeX Warning.*undefined" "$log_file"; then
+        return 1  # References still undefined
+    fi
+
+    # Check for citation warnings
+    if [[ -f "$log_file" ]] && grep -q "LaTeX Warning.*Citation" "$log_file"; then
+        return 1  # Citations still undefined
+    fi
+
+    # Check for "Rerun to get cross-references right"
+    if [[ -f "$log_file" ]] && grep -q "Rerun to get cross-references right" "$log_file"; then
+        return 1  # Need to rerun
+    fi
+
+    return 0  # All references resolved
+}
+
+# Step 3: Check if bibliography is needed and handle multiple compilations
+# Wait a moment for aux file to be fully written
+sleep 1
+if grep -q "\\\\bibdata\\|\\\\citation" "../../../build/${TEX_BASE}.aux" 2>/dev/null; then
+    log_info "Step 3: Running pBibTeX..."
+    cd ../../../build
+
+    # Copy necessary files
+    cp "../${SOURCE_DIR}"/*.bib . 2>/dev/null || log_warn "No .bib files found"
+    cp "../${SOURCE_DIR}"/*.bst . 2>/dev/null || log_warn "No .bst files found"
+
+    # Run pBibTeX with verbose output for debugging
+    if pbibtex "$TEX_BASE"; then
+        log_info "pBibTeX completed successfully"
+        # Copy .bbl file back to source directory
+        cp "${TEX_BASE}.bbl" "../${SOURCE_DIR}/" 2>/dev/null || log_warn "Failed to copy .bbl file"
+    else
+        log_warn "pBibTeX failed, continuing without bibliography"
+    fi
+
+    cd "$WORKSPACE/$SOURCE_DIR"
+else
+    log_info "No bibliography found, skipping pBibTeX"
+    cd "$WORKSPACE/$SOURCE_DIR"
+fi
+
+# Step 4-N: Compile until all references are resolved
+log_info "Step 4: Compiling until all references are resolved..."
+compile_count=2
+max_compiles=10
+
+while [[ $compile_count -le $max_compiles ]]; do
+    log_info "LaTeX compilation #${compile_count}..."
+    if ! eval "$LANG_ENV $COMPILER -output-directory=../../../build -interaction=nonstopmode '${TEX_BASE}.tex'" > /dev/null 2>&1; then
+        log_warn "LaTeX compilation #${compile_count} had warnings/errors (continuing)"
+    fi
+
+    # Check if references are resolved
+    if check_references; then
+        log_info "All references resolved after ${compile_count} compilations"
+        break
+    elif [[ $compile_count -eq $max_compiles ]]; then
+        log_warn "Reached maximum compilations ($max_compiles). Some references may still be unresolved."
+        break
+    else
+        log_info "References still unresolved, continuing..."
+        ((compile_count++))
+    fi
+done
+
+# Step 5: Copy images to build directory
+log_info "Step 5: Copying images to build directory..."
+cd "$WORKSPACE/build"
+if [[ -d "../${SOURCE_DIR}/images" ]]; then
+    cp -r "../${SOURCE_DIR}/images" . 2>/dev/null || log_warn "Failed to copy images directory"
+    log_info "Images copied successfully"
+else
+    log_warn "No images directory found"
+fi
+
+# Step 6: Generate PDF
+log_info "Step 6: Generating PDF..."
+if [[ -f "${TEX_BASE}.dvi" ]]; then
+    if dvipdfmx "${TEX_BASE}.dvi" 2>/dev/null || [[ -f "${TEX_BASE}.pdf" ]]; then
+        log_info "PDF generation successful"
+        
+        # Copy PDF to output directory
+        PDF_OUTPUT_DIR="../pdf/IPSJ/${ENCODING}"
+        mkdir -p "$PDF_OUTPUT_DIR"
+        if cp "${TEX_BASE}.pdf" "$PDF_OUTPUT_DIR/" 2>/dev/null; then
+            log_info "=== Compilation completed successfully ==="
+            log_info "PDF: pdf/IPSJ/${ENCODING}/${TEX_BASE}.pdf"
+            ls -la "$PDF_OUTPUT_DIR/${TEX_BASE}.pdf" 2>/dev/null || log_warn "PDF file not found in final location"
+        else
+            log_error "Failed to copy PDF to output directory"
+            exit 1
+        fi
+    else
+        log_error "DVI to PDF conversion failed"
+        exit 1
+    fi
+else
+    log_error "DVI file not generated"
+    exit 1
+fi

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -175,7 +175,7 @@ convert_dvi_to_pdf() {
     # 絶対パスを使用してDVI→PDF変換
     local abs_dvi_file
     local abs_pdf_output
-    
+
     # buildディレクトリは常に/workspace/buildに正規化
     if [[ "$output_dir" == "../../../build" ]]; then
       abs_dvi_file="/workspace/build/$(basename "$tex" .tex).dvi"
@@ -193,14 +193,14 @@ convert_dvi_to_pdf() {
       else
         abs_dvi_file="/workspace/$dvi_file"
       fi
-      
+
       if [[ "$pdf_output" = /* ]]; then
         abs_pdf_output="$pdf_output"
       else
         abs_pdf_output="/workspace/$pdf_output"
       fi
     fi
-    
+
     log_debug "Converting DVI to PDF: dvipdfmx -o $abs_pdf_output $abs_dvi_file"
     if dvipdfmx -o "$abs_pdf_output" "$abs_dvi_file"; then
       log_info "LaTeX compilation successful for $tex"
@@ -223,7 +223,7 @@ compile_unified() {
   local encoding="$2"
 
   local tex_base="$(basename "$tex" .tex)"
-  
+
   log_info "Unified compilation for $tex (encoding: $encoding)"
   bash /workspace/scripts/full-compile.sh "$tex_base" "$encoding" || log_error "Unified compilation failed for $tex"
 }

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 
 cd /workspace || {
   echo "[ERROR] Cannot change directory to /workspace" >&2
@@ -16,38 +16,42 @@ tex_compile() {
     # ディレクトリを適切に設定
     if [[ "$tex" =~ IPSJ/UTF8/ ]]; then
       cd src/IPSJ/UTF8
-      echo "[INFO] IPSJ format: Converting punctuation marks"
-      sed 's/、/，/g; s/。/．/g' "$(basename "$tex")" > "$(basename "$tex" .tex)_converted.tex"
-      tex_file="$(basename "$tex" .tex)_converted.tex"
+      tex_file="$(basename "$tex")"
     else
       cd src/UTF8
       tex_file="$(basename "$tex")"
     fi
 
-    # 古いファイルをクリーンアップ
-    rm -f "$(basename "$tex" .tex)".{aux,dvi,log,out,toc,synctex.gz}
+    # 古いファイルをクリーンアップ（buildディレクトリから）
+    rm -f "../../../build/$(basename "$tex" .tex)".{aux,dvi,log,out,toc,synctex.gz}
 
     # TEXINPUTSパスをディレクトリに応じて設定
     if [[ "$tex" =~ IPSJ/ ]]; then
       texinputs_path=".:./../../../src//:"
       build_path="../../../build/$(basename "$tex" .tex).pdf"
+      output_dir="../../../build"
     else
       texinputs_path=.:../../src//:
       build_path="../../build/$(basename "$tex" .tex).pdf"
+      output_dir="../../build"
     fi
 
-    if TEXINPUTS="$texinputs_path" LANG=ja_JP.UTF-8 LC_ALL=ja_JP.UTF-8 uplatex -interaction=nonstopmode "$tex_file"; then
-      if dvipdfmx -o "$build_path" "$(basename "$tex" .tex).dvi"; then
+    # 中間ファイルをbuildディレクトリに出力するためのオプション
+    TEXINPUTS="$texinputs_path" LANG=ja_JP.UTF-8 LC_ALL=ja_JP.UTF-8 uplatex -output-directory="$output_dir" -interaction=nonstopmode "$tex_file" || true
+    dvi_file="$output_dir/$(basename "$tex" .tex).dvi"
+    
+    # DVIファイルが生成されていれば成功とみなす（警告があっても）
+    if [[ -f "$dvi_file" ]]; then
+      pdf_output="$output_dir/$(basename "$tex" .tex).pdf"
+      if dvipdfmx -o "$pdf_output" "$dvi_file" 2>/dev/null; then
         echo "[INFO] LaTeX compilation successful for $tex"
       else
         echo "[WARN] DVI to PDF conversion failed for $tex"
       fi
     else
-      echo "[WARN] LaTeX compilation failed for $tex"
+      echo "[WARN] LaTeX compilation failed for $tex - DVI file not generated"
     fi
 
-    # 一時ファイルをクリーンアップ
-    [[ "$tex" =~ IPSJ/ ]] && rm -f "$(basename "$tex" .tex)_converted.tex"
     cd - >/dev/null
   elif [[ "$tex" =~ SJIS/ ]]; then
     echo "[INFO] SJIS encoding detected: $tex"
@@ -55,51 +59,59 @@ tex_compile() {
     # ディレクトリを適切に設定
     if [[ "$tex" =~ IPSJ/SJIS/ ]]; then
       cd src/IPSJ/SJIS
-      echo "[INFO] IPSJ format: Converting punctuation marks"
-      sed 's/、/，/g; s/。/．/g' "$(basename "$tex")" > "$(basename "$tex" .tex)_converted.tex"
-      tex_file="$(basename "$tex" .tex)_converted.tex"
+      tex_file="$(basename "$tex")"
     else
       cd src/SJIS
       tex_file="$(basename "$tex")"
     fi
 
-    # 古いファイルをクリーンアップ
-    rm -f "$(basename "$tex" .tex)".{aux,dvi,log,out,toc,synctex.gz}
+    # 古いファイルをクリーンアップ（buildディレクトリから）
+    rm -f "../../../build/$(basename "$tex" .tex)".{aux,dvi,log,out,toc,synctex.gz}
 
     # TEXINPUTSパスをディレクトリに応じて設定
     if [[ "$tex" =~ IPSJ/ ]]; then
       texinputs_path=".:./../../../src//:"
       build_path="../../../build/$(basename "$tex" .tex).pdf"
+      output_dir="../../../build"
     else
       texinputs_path=.:../../src//:
       build_path="../../build/$(basename "$tex" .tex).pdf"
+      output_dir="../../build"
     fi
 
-    if TEXINPUTS="$texinputs_path" LANG=ja_JP.SJIS LC_ALL=ja_JP.SJIS platex -interaction=nonstopmode "$tex_file"; then
-      if dvipdfmx -o "$build_path" "$(basename "$tex" .tex).dvi"; then
+    # 中間ファイルをbuildディレクトリに出力するためのオプション
+    TEXINPUTS="$texinputs_path" LANG=ja_JP.SJIS LC_ALL=ja_JP.SJIS platex -output-directory="$output_dir" -interaction=nonstopmode "$tex_file" || true
+    dvi_file="$output_dir/$(basename "$tex" .tex).dvi"
+    
+    # DVIファイルが生成されていれば成功とみなす（警告があっても）
+    if [[ -f "$dvi_file" ]]; then
+      pdf_output="$output_dir/$(basename "$tex" .tex).pdf"
+      if dvipdfmx -o "$pdf_output" "$dvi_file" 2>/dev/null; then
         echo "[INFO] LaTeX compilation successful for $tex"
       else
         echo "[WARN] DVI to PDF conversion failed for $tex"
       fi
     else
-      echo "[WARN] LaTeX compilation failed for $tex"
+      echo "[WARN] LaTeX compilation failed for $tex - DVI file not generated"
     fi
     
-    # 一時ファイルをクリーンアップ
-    [[ "$tex" =~ IPSJ/ ]] && rm -f "$(basename "$tex" .tex)_converted.tex"
     cd - >/dev/null
   else
     echo "[INFO] Standard encoding: $tex"
-    # 古いファイルをクリーンアップ
-    rm -f "$(basename "$tex" .tex)".{aux,dvi,log,out,toc,synctex.gz}
-    if TEXINPUTS=./src//: LANG=ja_JP.UTF-8 LC_ALL=ja_JP.UTF-8 uplatex -interaction=nonstopmode "$tex"; then
-      if dvipdfmx -o "build/$(basename "$tex" .tex).pdf" "$(basename "$tex" .tex).dvi"; then
+    # 古いファイルをクリーンアップ（buildディレクトリから）
+    rm -f "build/$(basename "$tex" .tex)".{aux,dvi,log,out,toc,synctex.gz}
+    TEXINPUTS=./src//: LANG=ja_JP.UTF-8 LC_ALL=ja_JP.UTF-8 uplatex -output-directory=build -interaction=nonstopmode "$tex" || true
+    dvi_file="build/$(basename "$tex" .tex).dvi"
+    
+    # DVIファイルが生成されていれば成功とみなす（警告があっても）
+    if [[ -f "$dvi_file" ]]; then
+      if dvipdfmx -o "build/$(basename "$tex" .tex).pdf" "$dvi_file" 2>/dev/null; then
         echo "[INFO] LaTeX compilation successful for $tex"
       else
         echo "[WARN] DVI to PDF conversion failed for $tex"
       fi
     else
-      echo "[WARN] LaTeX compilation failed for $tex"
+      echo "[WARN] LaTeX compilation failed for $tex - DVI file not generated"
     fi
   fi
 
@@ -108,10 +120,17 @@ tex_compile() {
   local pdf_dir="pdf/$(dirname "$rel_path")"
   mkdir -p "$pdf_dir"
   local pdf_name="${rel_path%.tex}.pdf"
-  if cp "build/$(basename "$tex" .tex).pdf" "pdf/$pdf_name" 2>/dev/null; then
-    echo "[INFO] PDF created: pdf/$pdf_name"
+  local build_pdf="build/$(basename "$tex" .tex).pdf"
+  
+  # PDFが存在するかチェックしてからコピー
+  if [[ -f "$build_pdf" ]]; then
+    if cp "$build_pdf" "pdf/$pdf_name"; then
+      echo "[INFO] PDF created: pdf/$pdf_name"
+    else
+      echo "[WARN] Failed to copy PDF for $tex"
+    fi
   else
-    echo "[WARN] Failed to copy PDF for $tex"
+    echo "[WARN] Build PDF not found: $build_pdf"
   fi
 }
 

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -9,72 +9,140 @@ cd /workspace || {
 tex_compile() {
   local tex="$1"
   echo "[INFO] Compiling: $tex"
-  TEXINPUTS=./src//: LANG=ja_JP.UTF-8 LC_ALL=ja_JP.UTF-8 latexmk -pdfdvi "$tex"
-  mkdir -p pdf
-  cp "build/$(basename "$tex" .tex).pdf" pdf/ || echo "[WARN] Failed to copy PDF for $tex"
-}
 
-compile_all() {
-  for tex in src/*.tex; do
-    [ -f "$tex" ] && tex_compile "$tex"
-  done
-  echo "[INFO] Compilation finished. Watching for further changes..."
-}
+  if [[ "$tex" =~ UTF8/ ]]; then
+    echo "[INFO] UTF-8 encoding detected: $tex"
 
-###############################
-# 監視方式の自動選択
-###############################
-monitor_method="polling"
-if command -v inotifywait >/dev/null 2>&1; then
-  echo "[INFO] Checking inotify functionality on mounted directory..."
-  testfile="src/.inotify_test_$$"
-  inotifywait -qq -e create "src" --timeout 1 &
-  pid=$!
-  touch "$testfile"
-  if wait $pid 2>/dev/null; then
-    monitor_method="inotify"
-    echo "[INFO] inotify events detected on mounted directory. Using inotify."
+    # ディレクトリを適切に設定
+    if [[ "$tex" =~ IPSJ/UTF8/ ]]; then
+      cd src/IPSJ/UTF8
+      echo "[INFO] IPSJ format: Converting punctuation marks"
+      sed 's/、/，/g; s/。/．/g' "$(basename "$tex")" > "$(basename "$tex" .tex)_converted.tex"
+      tex_file="$(basename "$tex" .tex)_converted.tex"
+    else
+      cd src/UTF8
+      tex_file="$(basename "$tex")"
+    fi
+
+    # 古いファイルをクリーンアップ
+    rm -f "$(basename "$tex" .tex)".{aux,dvi,log,out,toc,synctex.gz}
+
+    # TEXINPUTSパスをディレクトリに応じて設定
+    if [[ "$tex" =~ IPSJ/ ]]; then
+      texinputs_path=".:./../../../src//:"
+      build_path="../../../build/$(basename "$tex" .tex).pdf"
+    else
+      texinputs_path=.:../../src//:
+      build_path="../../build/$(basename "$tex" .tex).pdf"
+    fi
+
+    if TEXINPUTS="$texinputs_path" LANG=ja_JP.UTF-8 LC_ALL=ja_JP.UTF-8 uplatex -interaction=nonstopmode "$tex_file"; then
+      if dvipdfmx -o "$build_path" "$(basename "$tex" .tex).dvi"; then
+        echo "[INFO] LaTeX compilation successful for $tex"
+      else
+        echo "[WARN] DVI to PDF conversion failed for $tex"
+      fi
+    else
+      echo "[WARN] LaTeX compilation failed for $tex"
+    fi
+
+    # 一時ファイルをクリーンアップ
+    [[ "$tex" =~ IPSJ/ ]] && rm -f "$(basename "$tex" .tex)_converted.tex"
+    cd - >/dev/null
+  elif [[ "$tex" =~ SJIS/ ]]; then
+    echo "[INFO] SJIS encoding detected: $tex"
+
+    # ディレクトリを適切に設定
+    if [[ "$tex" =~ IPSJ/SJIS/ ]]; then
+      cd src/IPSJ/SJIS
+      echo "[INFO] IPSJ format: Converting punctuation marks"
+      sed 's/、/，/g; s/。/．/g' "$(basename "$tex")" > "$(basename "$tex" .tex)_converted.tex"
+      tex_file="$(basename "$tex" .tex)_converted.tex"
+    else
+      cd src/SJIS
+      tex_file="$(basename "$tex")"
+    fi
+
+    # 古いファイルをクリーンアップ
+    rm -f "$(basename "$tex" .tex)".{aux,dvi,log,out,toc,synctex.gz}
+
+    # TEXINPUTSパスをディレクトリに応じて設定
+    if [[ "$tex" =~ IPSJ/ ]]; then
+      texinputs_path=".:./../../../src//:"
+      build_path="../../../build/$(basename "$tex" .tex).pdf"
+    else
+      texinputs_path=.:../../src//:
+      build_path="../../build/$(basename "$tex" .tex).pdf"
+    fi
+
+    if TEXINPUTS="$texinputs_path" LANG=ja_JP.SJIS LC_ALL=ja_JP.SJIS platex -interaction=nonstopmode "$tex_file"; then
+      if dvipdfmx -o "$build_path" "$(basename "$tex" .tex).dvi"; then
+        echo "[INFO] LaTeX compilation successful for $tex"
+      else
+        echo "[WARN] DVI to PDF conversion failed for $tex"
+      fi
+    else
+      echo "[WARN] LaTeX compilation failed for $tex"
+    fi
+    
+    # 一時ファイルをクリーンアップ
+    [[ "$tex" =~ IPSJ/ ]] && rm -f "$(basename "$tex" .tex)_converted.tex"
+    cd - >/dev/null
   else
-    echo "[WARN] inotify events NOT detected on mounted directory. Falling back to polling."
+    echo "[INFO] Standard encoding: $tex"
+    # 古いファイルをクリーンアップ
+    rm -f "$(basename "$tex" .tex)".{aux,dvi,log,out,toc,synctex.gz}
+    if TEXINPUTS=./src//: LANG=ja_JP.UTF-8 LC_ALL=ja_JP.UTF-8 uplatex -interaction=nonstopmode "$tex"; then
+      if dvipdfmx -o "build/$(basename "$tex" .tex).pdf" "$(basename "$tex" .tex).dvi"; then
+        echo "[INFO] LaTeX compilation successful for $tex"
+      else
+        echo "[WARN] DVI to PDF conversion failed for $tex"
+      fi
+    else
+      echo "[WARN] LaTeX compilation failed for $tex"
+    fi
   fi
-  rm -f "$testfile"
-fi
 
-echo "[INFO] Using $monitor_method based monitoring"
+  # サブディレクトリ構造を維持してPDFをコピー
+  local rel_path="${tex#src/}"
+  local pdf_dir="pdf/$(dirname "$rel_path")"
+  mkdir -p "$pdf_dir"
+  local pdf_name="${rel_path%.tex}.pdf"
+  if cp "build/$(basename "$tex" .tex).pdf" "pdf/$pdf_name" 2>/dev/null; then
+    echo "[INFO] PDF created: pdf/$pdf_name"
+  else
+    echo "[WARN] Failed to copy PDF for $tex"
+  fi
+}
 
-###############################
-# inotify 監視
-###############################
-if [[ "$monitor_method" == "inotify" ]]; then
-  while inotifywait -qq -r -e modify,create,delete,move src/; do
-    echo "[INFO] Change detected via inotify"
-    compile_all
-  done
-  exit 0
-fi
+compile_single() {
+  local tex="$1"
+  tex_compile "$tex"
+  echo "[INFO] Single file compilation finished for: $tex"
+}
 
-###############################
-# ポーリング監視 (全環境対応)
-###############################
+# シグナルハンドリング
+trap 'echo "[INFO] Watch stopped"; exit 0' SIGINT SIGTERM
+
+echo "[INFO] Using polling method for Docker mount compatibility"
+
+# ポーリング監視
 declare -A file_times
-for tex in src/*.tex; do
-  [[ -f "$tex" ]] && file_times["$tex"]=$(stat -c %Y "$tex" 2>/dev/null || stat -f %m "$tex")
+
+# 初期ファイル時刻を記録
+while IFS= read -r -d '' tex; do
+  file_times["$tex"]=$(stat -c %Y "$tex" 2>/dev/null || stat -f %m "$tex")
   echo "[INFO] Tracking: $tex"
-done
+done < <(find src -name "*.tex" -type f -print0)
 
 while true; do
-  changed=false
-  for tex in src/*.tex; do
-    if [[ -f "$tex" ]]; then
-      current=$(stat -c %Y "$tex" 2>/dev/null || stat -f %m "$tex")
-      if [[ "${file_times[$tex]:-}" != "$current" ]]; then
-        changed=true
-        file_times["$tex"]=$current
-        echo "[INFO] Change detected in: $tex"
-      fi
+  while IFS= read -r -d '' tex; do
+    current=$(stat -c %Y "$tex" 2>/dev/null || stat -f %m "$tex")
+    if [[ "${file_times[$tex]:-}" != "$current" ]]; then
+      file_times["$tex"]=$current
+      echo "[INFO] Change detected in: $tex"
+      compile_single "$tex"
     fi
-  done
-  if $changed; then
-    compile_all
-  fi
-done 
+  done < <(find src -name "*.tex" -type f -print0)
+  sleep 1
+done

--- a/src/IPSJ/SJIS/.gitignore
+++ b/src/IPSJ/SJIS/.gitignore
@@ -1,0 +1,4 @@
+*
+!.gitignore
+!.latexmkrc
+!EIP109_kimura.tex

--- a/src/IPSJ/SJIS/.latexmkrc
+++ b/src/IPSJ/SJIS/.latexmkrc
@@ -1,43 +1,17 @@
 #!/usr/bin/env perl
 
-# Shift JIS 専用設定
+# pLaTeX + dvipdfmx 用設定（UTF-8専用）
 
-# LaTeX 処理系の設定（SJIS用）
-$latex = 'platex -synctex=1 -halt-on-error -interaction=nonstopmode -file-line-error';
-$pdflatex = 'pdflatex -synctex=1 -halt-on-error -interaction=nonstopmode -file-line-error';
-$lualatex = 'lualatex -synctex=1 -halt-on-error -interaction=nonstopmode -file-line-error';
-$xelatex = 'xelatex -synctex=1 -halt-on-error -interaction=nonstopmode -file-line-error';
+# LaTeX 処理系の設定（uplatex使用）
+$latex = 'uplatex %O -synctex=1 -interaction=nonstopmode %S';
+$pdflatex = 'pdflatex %O -synctex=1 -interaction=nonstopmode %S';
 
-# BibTeX 処理系の設定
-$bibtex = 'pbibtex %O %B';
-$biber = 'biber %O --bblencoding=utf8 -u -U --output_safechars %B';
+# DVI -> PDF変換の設定（dvipdfmx使用）
+$dvipdf = 'dvipdfmx %O -o %D %S';
 
-# インデックス処理系の設定
-$makeindex = 'mendex -r -c -s jind.ist';
+$dvips = 'dvips %O -z -f %S | convbkmk -u > %D';
+$ps2pdf = 'ps2pdf %O %S %D';
 
-# DVI -> PDF変換の設定
-$dvipdf = 'dvipdfmx -o %D %O %S';
-
-# PDF 生成方法の設定（platex + dvipdfmx）
+# PDF 生成方法の設定
+# 3: LaTeX -> DVI -> PDF (uplatex + dvipdfmx)
 $pdf_mode = 3;
-
-# 出力ディレクトリの設定
-$out_dir = '../../build';
-
-# 自動プレビューを無効化
-$preview_continuous_mode = 0;
-$preview_mode = 0;
-
-# 最大繰り返し数を設定
-$max_repeat = 5;
-
-# エラー時の動作
-$failure_cmd = '';
-
-# 日本語対応（SJIS）
-$ENV{'LANG'} = 'ja_JP.SJIS';
-$ENV{'LC_ALL'} = 'ja_JP.SJIS';
-
-# フォント警告を許可（警告でもコンパイルを続行）
-$warnings_as_errors = 0;
-$force_mode = 1;  # フォントエラーでも強制的に続行

--- a/src/IPSJ/SJIS/.latexmkrc
+++ b/src/IPSJ/SJIS/.latexmkrc
@@ -1,0 +1,43 @@
+#!/usr/bin/env perl
+
+# Shift JIS 専用設定
+
+# LaTeX 処理系の設定（SJIS用）
+$latex = 'platex -synctex=1 -halt-on-error -interaction=nonstopmode -file-line-error';
+$pdflatex = 'pdflatex -synctex=1 -halt-on-error -interaction=nonstopmode -file-line-error';
+$lualatex = 'lualatex -synctex=1 -halt-on-error -interaction=nonstopmode -file-line-error';
+$xelatex = 'xelatex -synctex=1 -halt-on-error -interaction=nonstopmode -file-line-error';
+
+# BibTeX 処理系の設定
+$bibtex = 'pbibtex %O %B';
+$biber = 'biber %O --bblencoding=utf8 -u -U --output_safechars %B';
+
+# インデックス処理系の設定
+$makeindex = 'mendex -r -c -s jind.ist';
+
+# DVI -> PDF変換の設定
+$dvipdf = 'dvipdfmx -o %D %O %S';
+
+# PDF 生成方法の設定（platex + dvipdfmx）
+$pdf_mode = 3;
+
+# 出力ディレクトリの設定
+$out_dir = '../../build';
+
+# 自動プレビューを無効化
+$preview_continuous_mode = 0;
+$preview_mode = 0;
+
+# 最大繰り返し数を設定
+$max_repeat = 5;
+
+# エラー時の動作
+$failure_cmd = '';
+
+# 日本語対応（SJIS）
+$ENV{'LANG'} = 'ja_JP.SJIS';
+$ENV{'LC_ALL'} = 'ja_JP.SJIS';
+
+# フォント警告を許可（警告でもコンパイルを続行）
+$warnings_as_errors = 0;
+$force_mode = 1;  # フォントエラーでも強制的に続行

--- a/src/IPSJ/UTF8/.gitignore
+++ b/src/IPSJ/UTF8/.gitignore
@@ -1,0 +1,4 @@
+*
+!.gitignore
+!.latexmkrc
+!EIP109_kimura.tex

--- a/src/IPSJ/UTF8/.latexmkrc
+++ b/src/IPSJ/UTF8/.latexmkrc
@@ -1,43 +1,17 @@
 #!/usr/bin/env perl
 
-# UTF-8 専用設定
+# pLaTeX + dvipdfmx 用設定（UTF-8専用）
 
-# LaTeX 処理系の設定（UTF-8用）
-$latex = 'uplatex -synctex=1 -halt-on-error -interaction=nonstopmode -file-line-error';
-$pdflatex = 'pdflatex -synctex=1 -halt-on-error -interaction=nonstopmode -file-line-error';
-$lualatex = 'lualatex -synctex=1 -halt-on-error -interaction=nonstopmode -file-line-error';
-$xelatex = 'xelatex -synctex=1 -halt-on-error -interaction=nonstopmode -file-line-error';
+# LaTeX 処理系の設定（uplatex使用）
+$latex = 'uplatex %O -synctex=1 -interaction=nonstopmode %S';
+$pdflatex = 'pdflatex %O -synctex=1 -interaction=nonstopmode %S';
 
-# BibTeX 処理系の設定
-$bibtex = 'upbibtex %O %B';
-$biber = 'biber %O --bblencoding=utf8 -u -U --output_safechars %B';
+# DVI -> PDF変換の設定（dvipdfmx使用）
+$dvipdf = 'dvipdfmx %O -o %D %S';
 
-# インデックス処理系の設定
-$makeindex = 'mendex -r -c -s jind.ist';
+$dvips = 'dvips %O -z -f %S | convbkmk -u > %D';
+$ps2pdf = 'ps2pdf %O %S %D';
 
-# DVI -> PDF変換の設定
-$dvipdf = 'dvipdfmx -o %D %O %S';
-
-# PDF 生成方法の設定（uplatex + dvipdfmx）
+# PDF 生成方法の設定
+# 3: LaTeX -> DVI -> PDF (uplatex + dvipdfmx)
 $pdf_mode = 3;
-
-# 出力ディレクトリの設定
-$out_dir = '../../build';
-
-# 自動プレビューを無効化
-$preview_continuous_mode = 0;
-$preview_mode = 0;
-
-# 最大繰り返し数を設定
-$max_repeat = 5;
-
-# エラー時の動作
-$failure_cmd = '';
-
-# 日本語対応の強化（UTF-8）
-$ENV{'LANG'} = 'ja_JP.UTF-8';
-$ENV{'LC_ALL'} = 'ja_JP.UTF-8';
-
-# フォント警告を許可（警告でもコンパイルを続行）
-$warnings_as_errors = 0;
-$force_mode = 1;  # フォントエラーでも強制的に続行

--- a/src/IPSJ/UTF8/.latexmkrc
+++ b/src/IPSJ/UTF8/.latexmkrc
@@ -1,0 +1,43 @@
+#!/usr/bin/env perl
+
+# UTF-8 専用設定
+
+# LaTeX 処理系の設定（UTF-8用）
+$latex = 'uplatex -synctex=1 -halt-on-error -interaction=nonstopmode -file-line-error';
+$pdflatex = 'pdflatex -synctex=1 -halt-on-error -interaction=nonstopmode -file-line-error';
+$lualatex = 'lualatex -synctex=1 -halt-on-error -interaction=nonstopmode -file-line-error';
+$xelatex = 'xelatex -synctex=1 -halt-on-error -interaction=nonstopmode -file-line-error';
+
+# BibTeX 処理系の設定
+$bibtex = 'upbibtex %O %B';
+$biber = 'biber %O --bblencoding=utf8 -u -U --output_safechars %B';
+
+# インデックス処理系の設定
+$makeindex = 'mendex -r -c -s jind.ist';
+
+# DVI -> PDF変換の設定
+$dvipdf = 'dvipdfmx -o %D %O %S';
+
+# PDF 生成方法の設定（uplatex + dvipdfmx）
+$pdf_mode = 3;
+
+# 出力ディレクトリの設定
+$out_dir = '../../build';
+
+# 自動プレビューを無効化
+$preview_continuous_mode = 0;
+$preview_mode = 0;
+
+# 最大繰り返し数を設定
+$max_repeat = 5;
+
+# エラー時の動作
+$failure_cmd = '';
+
+# 日本語対応の強化（UTF-8）
+$ENV{'LANG'} = 'ja_JP.UTF-8';
+$ENV{'LC_ALL'} = 'ja_JP.UTF-8';
+
+# フォント警告を許可（警告でもコンパイルを続行）
+$warnings_as_errors = 0;
+$force_mode = 1;  # フォントエラーでも強制的に続行

--- a/src/IPSJ/UTF8/EIP109_kimura.tex
+++ b/src/IPSJ/UTF8/EIP109_kimura.tex
@@ -1,0 +1,746 @@
+%%
+%% 研究報告用スイッチ
+%% [techrep]
+%%
+%% 欧文表記無しのスイッチ(etitle,eabstractは任意)
+%% [noauthor]
+%%
+
+%\documentclass[submit,techrep]{ipsj}
+\documentclass[submit,techrep,noauthor]{ipsj}
+
+% \usepackage[dvips]{graphicx}
+\usepackage[dvipdfmx]{graphicx}
+\usepackage{latexsym}
+
+\usepackage{amsmath}
+\usepackage{multirow}
+
+
+
+\def\Underline{\setbox0\hbox\bgroup\let\\\endUnderline}
+\def\endUnderline{\vphantom{y}\egroup\smash{\underline{\box0}}\\}
+\def\|{\verb|}
+
+% \setcounter{巻数}{59}
+% \setcounter{号数}{1}
+% \setcounter{page}{1}
+
+
+\受付{2025}{8}{27}
+% \再受付{2015}{7}{16}   %省略可能
+% \再再受付{2015}{7}{20} %省略可能
+% \再再受付{2015}{11}{20} %省略可能
+\採録{2025}{8}{27}
+
+
+
+
+\begin{document}
+
+
+\title{電子フォーム作成を目的とした\\
+記入欄自動検出およびラベル割付ツールの開発}
+
+% \etitle{Development of a Tool for Automatic Fill-in Fields Detection \\
+% and Labels Assignment to Generate Electronic Forms}
+
+\affiliate{UoM}{宮崎大学\\
+University of Miyazaki}
+\affiliate{CT}{codeless technology株式会社\\
+codeless technology inc.}
+
+% \affiliate{UoN}{長崎県立大学\\
+% University of Nagasaki}
+
+\author{木村 優哉}{Yuya Kimura}{UoM}[kimura@earth.cs.miyazaki-u.ac.jp]
+\author{片山 徹郎}{Tetsuro Katayama}{UoM}[kat@cs.miyazaki-u.ac.jp]
+\author{猿谷 吉行}{Yoshiyuki Saruya}{CT}[saruya@codeless-tech.com]
+\author{中武 範彰}{Noriaki Nakatake}{CT}[nakatake@codeless-tech.com]
+% \author{喜多 義弘}{Yoshihiro Kita}{UoN}
+% \author{山場 久昭}{Hisaaki Yamaba}{UoM}
+% \author{油田 健太郎}{Kentaro Aburada}{UoM}
+% \author{岡崎 直宣}{Naonobu Okazaki}{UoM}
+% \author{処理 花子}{Hanako Shori}{IPSJ}
+% \author{学会 次郎}{Jiro Gakkai}{IPSJ,JU}[gakkai.jiro@ipsj.or.jp]
+
+\begin{abstract}
+% 電⼦帳簿保存法が改正されたことにより，帳票のデータ保存が義務付けられ，帳票の電⼦化が推進されている．
+% 帳票の電⼦化は，スキャナやカメラで帳票を撮影することによって実現できる．
+% 簡単に電⼦化できる⼀⽅で，帳票に記⼊した内容は，⼈が⽬視で確認する必要がある．
+帳票の記入内容を効率的に管理する方法の1つとして，電子フォームを用いる方法がある．
+電子フォームを自動で作成するために，複数のツールが開発されている．
+しかし，帳票を紙媒体で管理している場合は，電子フォームを作成する際に，マウスのドラッグ操作で記入欄を配置する必要があるため，時間がかかるという課題がある．
+そこで本論文では，電子フォーム作成にかかる時間の削減を目的として，記入欄自動検出およびラベル割付ツールを開発する．
+開発するツールは，OpenCVによる画像処理で記入欄を自動検出し，その座標を取得する．
+また，光学文字認識により帳票内の文字と文字位置を取得し，大規模言語モデルにより，取得した文字から適切なデータ型（日付，文字列，数値）を推測する．
+さらに，推測したデータ型を参照して，ラベルを割り付ける．
+帳票構造を解析する既存研究と比較して，開発するツールはデータセットなどの事前準備が不要であり，電子文書と電子化文書の両方の帳票画像に対応できる．
+また，評価実験を行い，電子フォーム作成にかかる時間を削減できることを示した．
+
+% 効率的に帳票の記⼊内容を管理する⽅法の1つとして，電⼦フォームを⽤いる⽅法がある．
+% 電⼦フォームを⾃動で作成するために，複数のツールが開発されている．
+% しかし，帳票を紙媒体で管理している場合は，電⼦フォームを作成する際に，マウスのドラッグ操作で記⼊欄を配置する必要があるため，時間がかかるという課題がある．
+% そこで本論⽂は，電⼦フォーム作成にかかる時間の削減を⽬的として，記⼊欄⾃動検出およびラベル割付ツールを開発する．
+% 開発するツールは，帳票構造を解析する既存研究と⽐較して，データセットなどの事前準備が不要であり，電⼦⽂書，および，電⼦化⽂書の両⽅の帳票画像から記⼊欄を⾃動検出できる．
+% 評価実験を⾏い，電⼦フォーム作成にかかる時間を削減できることを⽰した．
+\end{abstract}
+
+
+\begin{jkeyword}
+画像処理，帳票構造解析，記入欄自動取得，光学文字認識，大規模言語モデル
+\end{jkeyword}
+
+% \begin{eabstract}
+% The digitalization of forms is being promoted because it is required saving as data format by amendment of Electronic Books Maintenance Act.
+% The digitalization of forms can be achieved by capturing them using a scanner or camera.
+% While this method offers the advantage of easy digitization, it also has the drawback that the contents filled in on the forms must be manually checked by a person.
+% One of the effective ways to manage contents filled in fields is using electronic forms.
+% Several tools have been developed to generate them automatically.
+% However, when you use a paper form, it takes time to generate electronic one because it is necessary to place fill-in fields on an electronic form by dragging them with a mouse.
+% This paper proposes a tool for automatic fill-in fields detection and labels assignment to reduce time required to place fill-in fields.
+% The developed tool does not require any preparation such as datasets, and it can automatically detect fill-in fields from both electronic documents and digitized documents.
+% From evaluation experiments, it has confirmed that the developed tool has reduced the time to generate an electronic form.
+% \end{eabstract}
+
+% \begin{ekeyword}
+% Image Processing, Form Structure Analysis, Automatic Fill-in Fields Detection, Optical Character Recognition, Large Language Models
+% \end{ekeyword}
+
+\maketitle
+
+% 1_introduction
+\section{はじめに}
+
+電子帳簿保存法が改正されたことにより，帳票のデータ保存が義務付けられ，帳票の電子化が推進されている\cite{specialwebsite_for_the_Electronic_Bookkeeping_System}．
+帳票の電子化は，スキャナやカメラで帳票を撮影することによって実現できる．
+簡単に電子化できる一方で，帳票に記入した内容は，人が目視で確認する必要がある．
+効率的に帳票の記入内容を管理する方法の1つとして，電子フォームを用いる方法がある．
+電子フォームを自動で作成するために，複数のツールが開発されている\cite{i-reporter}\cite{createform}．
+しかし，帳票を紙媒体で管理している場合は，電子フォームを作成する際に，マウスのドラッグ操作で記入欄を配置する必要があるため，時間がかかるという課題がある．
+
+そこで本論文では，電子フォーム作成にかかる時間の削減を目的として，記入欄自動検出およびラベル割付ツールを開発する．
+開発するツールは，以下の2つの機能を持つ．
+
+\begin{itemize}
+	\item 領域座標自動取得およびラベル割付機能 \\
+	領域座標自動取得およびラベル割付機能は，帳票画像を入力として，帳票画像中の矩形，および，下線で示された記入欄の座標をそれぞれ矩形領域座標，下線部領域座標として自動で取得し，各領域座標とそれに対してラベルを割り付けた結果をまとめたJSONファイルを出力とする機能である．
+	ラベルを割り付けることで，バリデーションチェックに必要な情報を付与できる．
+	\item 領域強調画像出力機能 \\
+	領域強調画像出力機能は，入力である帳票画像に対して，取得した領域座標とラベルを強調表示したPNG画像を出力する機能である．
+	これによって，領域座標自動取得およびラベル割付機能で出力したJSONファイルの内容を，目視で確認しやすくする．
+	本機能で出力する画像は，ランダムな色で，矩形，および，下線を描画した，1枚の領域強調画像である．
+\end{itemize}
+
+開発するツールは，帳票構造を解析する既存研究と比較して，データセットなどの事前準備が不要である．
+また，Wordやテキストファイルなど，デジタル情報として作成した文書である電子文書，および，紙媒体の書類をスキャンした，PDFファイルや画像の形式で保存した電子化文書の，両方の文書の画像から記入欄を自動検出できる．
+
+開発するツールは，以下の条件を全て満たす帳票画像を入力とする．
+なお，開発するツールにおいて，電子化文書はスマートフォンのカメラで撮影した帳票画像を想定する．
+
+\begin{itemize}
+	\item 帳票の電子文書または電子化文書の画像である
+	\item 帳票の背景が白色である
+	\item 日本語かつ横書きの帳票である
+	\item 文字が手書きではない
+	\item 入力欄が矩形または下線で示されている
+\end{itemize}
+
+また，開発するツールは，以下の2つを出力する．
+
+\begin{itemize}
+	\item 取得した領域座標とそれに対応するラベル，矩形領域と下線部領域のそれぞれで一意なID（番号）をまとめたJSONファイル
+	\item 取得した領域を色を付けて描画することで強調表示し，各領域座標に対応するラベルをテキストで描画した1枚の領域強調画像
+\end{itemize}
+
+
+% 2_related_research
+\section{関連研究}
+
+本章では，既存の電子フォーム作成ツールと，帳票構造解析の関連研究について述べる．
+帳票構造解析の関連研究については，事前準備が必要なものと，画像処理ベースのものに分けて述べる．
+
+\subsection{既存の電子フォーム作成ツール}
+
+既存の電子フォーム作成ツールである，i-Reporter\cite{i-reporter}やCreate!Form\cite{createform}は，帳票のExcelファイル，もしくは，画像ファイルを入力として，電子フォームを作成できる．
+これらの既存の電子フォーム作成ツールは，帳票をExcel ファイルとして管理している場合，Excel ファイルのレイアウトとセルの書式を保ったまま電子フォームを簡単に作成できる．
+一方，帳票を紙媒体で管理している場合は，既存の電子フォーム作成ツールを使用するために，帳票をExcel ファイルとして作成し，入力とするか，紙媒体の帳票を撮影した画像ファイルを入力として，電子フォームを手作業で作成する必要があり，それぞれ以下の2つの課題がある．
+
+\begin{itemize}
+	\item Excelファイルを入力とする場合，紙媒体の帳票のレイアウトをもとにExcelファイルを新たに作成する必要があり，使い慣れた既存の帳票のレイアウトが変わる場合がある．
+	\item 画像ファイルを入力とする場合，帳票の画像を背景として，GUIツールを用いたマウス操作で記入欄を配置する必要があるため，電子フォームの作成に時間がかかる．
+\end{itemize}
+
+% 2.1
+\subsection{事前準備が必要な関連研究}
+
+帳票構造解析の関連研究に，帳票構造テンプレートの登録や，学習モデルの準備などの，事前準備が必要なものがある\cite{10.5120/ijca2020919760}\cite{Nagarikar2021InputFR}\cite{lee-etal-2022-formnet}．
+
+例として，Kathait氏らの研究\cite{10.5120/ijca2020919760}では，帳票データのデジタル化を目的として，スキャンした帳票から手書きテキスト，および，チェックボックスを自動で抽出するシステムの提案と実装を行った．
+スキャンされたJPEG形式の手書き帳票画像とXMLファイルの帳票構造テンプレートを入力とし，JSON形式のレスポンスと，チェックボックスがあるかどうかを出力し，出力をデータベースへ登録する．
+帳票画像内の記入欄の座標や，何を記入すべきかを示す文字列を，XMLファイルとして格納することによって，帳票構造テンプレートを作成する．
+XMLファイルを用いたテンプレートマッチングによって，各記入欄の画像を別の画像ファイルとして保存する．
+また，Google Cloud Vision API\cite{google_cloud_vision_api}のTEXT\_DETECTION機能と，Inception v3の転移学習を用いて，帳票画像内の文字を取得する．
+Kathait氏らの研究では，手書き文字の認識ができる一方で，帳票構造テンプレートの登録や学習モデルの準備が必要である．
+
+% 2.2
+\subsection{画像処理ベースの関連研究}
+
+帳票構造解析の関連研究に，画像処理ベースの手法を用いたものがある\cite{yuan}\cite{711885}\cite{8786345}．
+
+例として，Yuan氏らの研究\cite{yuan}では，帳票のPDFファイルからページをまたぐ表構造を認識し，各セル内のテキストと位置関係をCSVファイルに出力する手法を提案した．
+PDFファイル，または，PNG形式やJPEG形式などの画像ファイルを入力とし，取得した文字を含むCSVファイルと，認識した表構造を強調表示する1枚の画像をそれぞれ出力する．
+OpenCV\cite{opencv_library}による画像処理とTesseractによる光学文字認識を用いて，テキストを含むセル同士の位置関係を，CSVファイルのセル構造に反映して保存する．
+矩形の記入欄の座標を処理の途中で表示するが，最終的な出力には含まない．
+Yuan氏らの研究では，ページをまたぐ表構造の認識ができる一方で，電子化文書のPDFについては入力対象外である．
+
+
+% 3_function
+\section{開発したツールの機能}
+
+本章では，開発したツールの機能について述べる．
+開発したツールは，以下の2つの機能を持つ．
+
+\begin{itemize}
+	\item 領域座標自動取得およびラベル割付機能
+	\item 領域強調画像出力機能
+\end{itemize}
+
+本研究では，開発したツールが帳票画像内の記入欄を検出し，取得した座標を領域座標，矩形の記入欄の領域座標を矩形領域座標，下線部の記入欄の領域座標を下線部領域座標とそれぞれ呼ぶ．
+また，光学文字認識によって得た文字から推測するデータ型を属性，文字の近傍に存在する領域座標に対して文字位置と属性から推測するデータ型をラベルと呼ぶ．
+
+% 3.1
+\subsection{領域座標自動取得およびラベル割付機能}
+
+領域座標自動取得およびラベル割付機能は，帳票画像中の矩形および下線で示された記入欄について，それらの領域座標を取得し，それぞれにラベルを割り付ける機能である．
+矩形領域座標として，左上頂点のxy座標，幅，および，高さを取得する．
+下線部領域座標として，左端点のxy座標，および，幅を取得する．
+入力は帳票画像であり，出力は領域座標とラベルをまとめたJSONファイルである．
+
+なお，出力するJSONファイルは，矩形領域のラベルと領域座標をまとめたrects配列と，下線部領域のラベルと領域座標をまとめたunderlines配列で構成する．
+出力する2つの配列は，以下のキーとオブジェクトから構成する．
+
+\begin{itemize}
+	\item 取得した各領域座標において，どの領域座標かを一意に定めるID（番号）を示すidキー
+	\item 領域座標に割り付けたラベルを示すlabelキー
+	\item 領域座標をまとめたcoordsオブジェクト
+	\begin{itemize}
+		\item 矩形領域の左上頂点，もしくは，下線部領域の左端点のx座標を示すxキー
+		\item 矩形領域の左上頂点，もしくは，下線部領域の左端点のy座標を示すyキー
+		\item 領域座標の幅を示すwidthキー
+		\item 領域座標の高さを示すheightキー（矩形領域座標のみ）
+	\end{itemize}
+\end{itemize}
+
+各領域座標のx座標，y座標を示すxキー，yキーはそれぞれ，画像左上を原点として，右方向をX軸の正方向，下方向をY軸の正方向とする座標系における座標値を示す．
+
+領域座標自動取得およびラベル割付機能が出力するJSONファイルの例を，\figref{fig:json}に示す．
+
+\begin{figure}[t]
+	\setbox0\vbox{
+		\hbox{\texttt{\{}}
+		\hbox{\texttt{\phantom{~~}"rects": [}}
+		\hbox{\texttt{\phantom{~~~~}\{}}
+		\hbox{\texttt{\phantom{~~~~~~}"id": 0,}}
+		\hbox{\texttt{\phantom{~~~~~~}"label": "string",}}
+		\hbox{\texttt{\phantom{~~~~~~}"coords": \{}}
+		\hbox{\texttt{\phantom{~~~~~~~~}"x": 339,}}
+		\hbox{\texttt{\phantom{~~~~~~~~}"y": 753,}}
+		\hbox{\texttt{\phantom{~~~~~~~~}"width": 900,}}
+		\hbox{\texttt{\phantom{~~~~~~~~}"height": 106}}
+		\hbox{\texttt{\phantom{~~~~~~}\}}}
+		\hbox{\texttt{\phantom{~~~~}\}}}
+		\hbox{\texttt{\phantom{~~}],}}
+		\hbox{\texttt{\phantom{~~}"underlines": [}}
+		\hbox{\texttt{\phantom{~~~~}\{}}
+		\hbox{\texttt{\phantom{~~~~~~}"id": 0,}}
+		\hbox{\texttt{\phantom{~~~~~~}"label": "string",}}
+		\hbox{\texttt{\phantom{~~~~~~}"coords": \{}}
+		\hbox{\texttt{\phantom{~~~~~~~~}"x": 1066,}}
+		\hbox{\texttt{\phantom{~~~~~~~~}"y": 298,}}
+		\hbox{\texttt{\phantom{~~~~~~~~}"width": 794}}
+		\hbox{\texttt{\phantom{~~~~~~}\}}}
+		\hbox{\texttt{\phantom{~~~~}\}}}
+		\hbox{\texttt{\phantom{~~}]}}
+		\hbox{\texttt{\}}}
+	}
+	\centerline{\fbox{\box0}}
+	\caption{出力するJSONファイルの例}
+	\ecaption{An example of output JSON file.}
+	\label{fig:json}
+\end{figure}
+
+各領域座標を取得するため，OpenCVによる画像処理を行う．
+出力するJSONファイルにおける，rects配列，および，underlines配列内のidキー，およびcoordsオブジェクトの各キーに対応する値を取得する．
+
+また，取得した各領域座標に対してラベルを割り付ける．
+入力である帳票画像に対してGoogle Cloud Vision APIによる光学文字認識を行う．
+帳票画像内の文字と，文字を囲むバウンディングボックスの各頂点のxy座標をそれぞれ取得する．
+文字を取得後，大規模言語モデルGemini\cite{gemini}による属性の推測を行う．
+本研究で用いる3つの属性を，以下に示す．
+
+\begin{itemize}
+	\item 日付（date）
+	\item 文字列（string）
+	\item 数値（number）
+\end{itemize}
+
+取得文字のデータ型が，上記3つのうちのいずれに該当するかを推測し，属性として取得する．
+
+領域座標，取得した文字とその文字位置，属性を用いて，文字位置の近傍に存在する領域座標を対象に属性を割り付け，ラベルとして取得する．
+出力するJSONファイルにおけるrects配列，および，underlines配列内の，labelキーに対応する値を取得する．
+
+% 3.2
+\subsection{領域強調画像出力機能}
+
+領域強調画像出力機能は，領域座標自動取得およびラベル割付機能で取得した領域とラベルを描画することによって，取得した領域を強調表示したPNG形式の画像を出力する機能である．
+入力は領域座標とラベルをまとめた組であり，出力は領域強調画像である．
+領域強調画像を出力することによって，領域座標自動取得およびラベル割付機能で出力したJSONファイルの内容を，目視で確認しやすくする．
+本機能で出力する画像は，ランダムな色で矩形，および，水平な直線と，その領域座標に割り付けたラベルを描画する．
+% 各領域をランダムな色で描画する理由は，矩形領域が隣接する際に，視認性が低下することを防ぐためである．
+
+領域強調画像出力機能が出力する領域強調画像の例を，\figref{fig:example_output_image}に示す．
+また，\figref{fig:example_output_image}の領域強調画像内で描画する，IDとラベルを示すテキストの形式を，\figref{fig:format_in_highlighted_image}に示す．
+
+\begin{figure}[t]
+	\begin{center}
+		\fbox{
+			\includegraphics[width=0.9\linewidth]{images/03_function/example_output_image.jpg}
+		}
+		\caption{出力する領域強調画像の例}
+		\ecaption{An example of the output highlighted area image.}
+		\label{fig:example_output_image}
+	\end{center}
+\end{figure}
+
+\begin{figure}[t]
+	\setbox0\vbox{
+		\hbox{\texttt{R\textless ID\textgreater :\textless label\textgreater}}
+		\hbox{\texttt{U\textless ID\textgreater :\textless label\textgreater}}
+	}
+	\centerline{\fbox{\box0}}
+	\caption{領域強調画像内に描画するテキストの形式}
+	\ecaption{Format of text drawn in the highlighted image.}
+	\label{fig:format_in_highlighted_image}
+\end{figure}
+
+IDとラベルを示すテキストは，矩形領域であればR，下線部領域であればUから始まる．
+\figref{fig:format_in_highlighted_image}の\textless ID\textgreater，および，\textless label\textgreater はそれぞれ，領域座標のIDとラベルを示し，出力するJSONファイルのidキー，labelキーに対応する値と一致する．
+
+% 4_implementation
+\section{開発したツールの実装}
+
+本章では，開発したツールの3つの処理部について述べる．
+開発したツールの構成を，\figref{fig:structure}に示す．
+
+\begin{figure*}[t]
+	\begin{center}
+		\includegraphics[width=0.9\linewidth,bb=0 0 1980 1114]{images/04_implementation/structure.jpg}
+		\caption{開発したツールの構成}
+		\ecaption{Structure of the developed tool.}
+		\label{fig:structure}
+	\end{center}
+\end{figure*}
+
+開発したツールは，領域座標取得部，ラベル割付部，ファイル出力部の3つの処理部で構成する．
+PNGもしくはJPEG形式の帳票画像を入力とし，記入欄を強調表示した画像と，記入欄の座標とラベルを含むJSONファイルを出力とする．
+入力として，電子文書，および，電子化文書の画像を受け取る．
+
+% 4.1
+\subsection{領域座標取得部}
+
+領域座標取得部は，帳票画像内の記入欄を検出し，領域座標を取得する処理部である．
+帳票画像を入力とし，領域座標を出力とする．
+出力は，ラベル割付部に渡す．
+矩形領域座標については左上頂点のxy座標と幅と高さを，下線部領域座標については左端点のxy座標と幅を，それぞれ取得する．
+
+領域座標取得部の処理の流れを，以下に示す．
+
+\begin{enumerate}
+	\item OpenCVのimread, cvtColor, GaussianBlur, threshold, getStructuringElement, および，dilate関数より，矩形領域座標取得のための画像を処理する．
+	\item OpenCVのfindContours関数より，矩形を検出し，矩形領域座標を取得する．
+	\item OpenCVのimread, cvtColor, および，threshold関数より，下線部領域座標取得のための画像を処理する．
+	\item OpenCVのHoughLinesP関数より，水平な直線を検出し，下線部領域座標を取得する．
+	\item 取得した矩形領域座標を参照し，取得した下線部領域座標のうち，矩形領域の一部であるものを除外する．
+	\item 画像左上を原点として，矩形領域座標を中心点のy座標が小さい順，y座標が同じである場合は，さらにx座標が小さい順にソートする．
+	\item 下線部領域座標も検出した直線の中点について，矩形領域の場合と同様にソートする．
+\end{enumerate}
+
+なお，矩形領域座標，および，下線部領域座標のソートする際に，y座標の差が10px以内である場合は，y座標が同じであるとみなしてグループ化する．
+グループ化後，x座標でグループ内を再ソートする．
+
+% 4.2
+\subsection{ラベル割付部}
+
+ラベル割付部は，取得した領域座標に対してラベルを割り付ける処理部である．
+領域座標取得部から受け取った領域座標を入力とし，領域座標とそのラベルの組を出力とする．
+出力は，ファイル出力部に渡す．
+ラベルを割り付けるため，帳票画像中の文字と文字位置を取得するため，Google Cloud Vision APIを用いる．
+また，属性を推測するため，大規模言語モデルであるGeminiを用いる．
+
+ラベル割付部の処理の流れを，以下に示す．
+
+\begin{enumerate}
+	\item 領域座標取得部で取得した矩形領域座標と下線部領域座標を，領域座標として受け取る．
+	\item Google Cloud Vision APIのTEXT\_DETECTION機能を用いて，帳票画像中の文字と文字位置を取得する．
+	\item 画像左上を原点として，文字位置の中心点のy座標が小さい順，y座標が同じである場合は，さらにx座標が小さい順にソートする．
+	\item 取得した文字から，日付，文字列，数値のいずれのデータ型に該当するかをGeminiによって推測し，属性として取得する．
+	\item ソートした文字の順番に従い，文字位置の中心点を基準として比較処理を行い，ラベルを割り付ける．
+	\begin{enumerate}
+		\item 矩形領域の右下頂点のx座標，および，y座標がどちらも大きい場合は，属性をその矩形領域のラベルとして割り付ける．
+		\item 下線部領域の右端点のx座標，および，y座標がどちらも大きい場合は，属性をその下線部領域のラベルとして割り付ける．
+	\end{enumerate}
+\end{enumerate}
+
+ラベルを割り付ける処理は，既にラベルを割りつけた記入欄については，あとに割りつけたラベルで上書きする．
+これは，日本語の帳票を書き進める順番に対応するため，および，別の領域座標のラベルを割り付けることを防ぐためである．
+例として，記入方向が変わる帳票の一部を，\figref{fig:label_order}に示す．
+
+\begin{figure}[t]
+	\begin{center}
+		\fbox{
+			\includegraphics[width=0.9\linewidth]{images/04_implementation/label_order.jpg}
+		}
+		\caption{記入方向が変わる帳票の例}
+		\ecaption{An example of a form with different writing directions.}
+		\label{fig:label_order}
+	\end{center}
+\end{figure}
+
+\figref{fig:label_order}の「合計」の列に，別の内容を記入する帳票画像内の記入欄が配置されている．
+このように，同じ内容を記入する縦方向に配置された帳票画像内の記入欄（\figref{fig:label_order}の青い矢印）の下に，別の内容を記入する横方向に配置された帳票画像内の記入欄（\figref{fig:label_order}の赤い矢印）がある場合についても，文字位置をソートした順番でラベルを更新する．
+これによって，別の文字の属性を参照することによる誤ったラベルの割り付けを防ぐ．
+
+% 4.3
+\subsection{ファイル出力部}
+
+ファイル出力部は，領域座標と，領域座標に対応するラベルを組とするJSON形式のファイル，および，JSONファイルの取得領域を強調表示したPNG形式の画像1枚を出力する処理部である．
+ラベル割付部から受け取った領域座標とそのラベルの組を入力とし，JSONファイルと1枚の領域強調画像を出力とする．
+
+出力するJSONファイルは，配列rectsと配列underlinesで構成し，矩形領域の情報と下線部領域の情報をそれぞれ持つ．
+配列rectsと，配列underlinesを，\figref{fig:json}に示す形式に整形後，JSONファイルを出力する．
+
+% 上の一文は下のをコメント外すなら，その下に移動すること
+% これら2つの配列は，それぞれ以下の情報をもつ．
+
+% \begin{itemize}
+% 	\item 配列ごとに一意であるid
+% 	\item 領域に割り付けているラベルを示すlabel
+% 	\item 領域座標を示すオブジェクトcoords
+% \end{itemize}
+
+出力する領域強調画像は，矩形領域と下線部領域をそれぞれランダムな色で描画し，各領域座標に対応するラベルをテキストで描画した1枚の画像である．
+描画するテキストの番号とラベルは，JSONファイルの各配列におけるidキーとlabelキーの値と一致する．
+
+% 5_indication
+\section{適用例}
+
+本章では，開発したツールが正しく動作することを，適用例を用いて確認する．
+紙面の都合上，矩形領域についてのみ本論文内で確認する．
+開発したツールに適用する帳票画像を，\figref{fig:example}に示す．
+
+\begin{figure}[t]
+	\begin{center}
+		\fbox{
+			\includegraphics[width=0.9\linewidth]{images/05_indication/example.jpg}
+		}
+		\caption{開発したツールを適用する帳票画像}
+		\ecaption{An example of a form to apply the developed tool.}
+		\label{fig:example}
+	\end{center}
+\end{figure}
+
+\figref{fig:example}の帳票画像を入力として，開発したツールが出力したJSONファイルと領域強調画像が，測定した矩形領域の位置，および，ラベルとそれぞれ一致することを確認する．
+% 具体的には，JSONファイルのrects配列と領域強調画像を参照し，矩形領域の出力結果を確認する．
+
+% 5.1
+% \subsection{矩形領域の出力結果}
+\figref{fig:example}の帳票画像を入力として，開発したツールが出力した領域強調画像のうち，矩形領域を強調した画像の一部を，\figref{fig:highlighted_rects_image}に示す．
+また，出力したJSONファイルのうち，rects配列の一部を，\figref{fig:highlighted_rects_json}に示す．
+
+\begin{figure}[t]
+	\begin{center}
+		\fbox{
+			\includegraphics[width=0.9\linewidth]{images/05_indication/highlighted_rects_image.jpg}
+		}
+		\caption{矩形領域を強調した領域強調画像の一部}
+		\ecaption{A part of the highlighted rectangle areas image.}
+		\label{fig:highlighted_rects_image}
+	\end{center}
+\end{figure}
+
+% 矩形領域について，出力するJSONファイルのrects配列におけるlabelキーに対応する値，およびcoordsオブジェクトの各キーに対応する値が，領域強調画像の出力と対応することを確認した．
+% 領域座標について，他の矩形領域に対しても，矩形領域座標を正しく取得していることを確認した．
+% ラベルについても，正しいラベルを割り付けていることを確認した．
+
+% % 5.2
+% \subsection{下線部領域の出力結果}
+% \figref{fig:example}に対して，開発したツールを適用し，出力した領域強調画像のうち，下線部領域を強調した画像の一部を，\figref{fig:highlighted_underlines_image}に示す．
+
+% \begin{figure}[t]
+% 	\begin{center}
+% 		\fbox{
+% 			\includegraphics[width=0.9\linewidth]{images/05_indication/highlighted_underlines_image.jpg}
+% 		}
+% 		\caption{下線部領域を強調した画像の一部}
+% 		\ecaption{A part of the highlighted underlined areas image.}
+% 		\label{fig:highlighted_underlines_image}
+% 	\end{center}
+% \end{figure}
+
+% 下線部領域について，出力するJSONファイルのunderlines配列におけるlabelキーに対応する値，およびcoordsオブジェクトの各値が，領域強調画像の出力と対応することを確認した．
+% 領域座標について，他の下線部領域に対しても，下線部領域座標を正しく取得していることを確認した．
+% ラベルについても，他の下線部領域に対して，正しいラベルを割り付けていることを確認した．
+
+\begin{figure}[t]
+	\setbox0\vbox{
+		\hbox{\texttt{\phantom{~~}\{}}
+		\hbox{\texttt{\phantom{~~~~}"id": 4,}}
+		\hbox{\texttt{\phantom{~~~~}"label": "string",}}
+		\hbox{\texttt{\phantom{~~~~}"coords": \{}}
+		\hbox{\texttt{\phantom{~~~~~~}"x": 275,}}
+		\hbox{\texttt{\phantom{~~~~~~}"y": 817,}}
+		\hbox{\texttt{\phantom{~~~~~~}"width": 733,}}
+		\hbox{\texttt{\phantom{~~~~~~}"height": 86}}
+		\hbox{\texttt{\phantom{~~~~}\}}}
+		\hbox{\texttt{\phantom{~~}\},}}
+		\hbox{\texttt{\phantom{~~}\{}}
+		\hbox{\texttt{\phantom{~~~~}"id": 5,}}
+		\hbox{\texttt{\phantom{~~~~}"label": "number",}}
+		\hbox{\texttt{\phantom{~~~~}"coords": \{}}
+		\hbox{\texttt{\phantom{~~~~~~}"x": 1016,}}
+		\hbox{\texttt{\phantom{~~~~~~}"y": 817,}}
+		\hbox{\texttt{\phantom{~~~~~~}"width": 292,}}
+		\hbox{\texttt{\phantom{~~~~~~}"height": 86}}
+		\hbox{\texttt{\phantom{~~~~}\}}}
+		\hbox{\texttt{\phantom{~~}\},}}
+	}
+	\centerline{\fbox{\box0}}
+	\caption{出力したJSONファイルのrects配列の一部}
+	\ecaption{A part of the output JSON file's rects array.}
+	\label{fig:highlighted_rects_json}
+\end{figure}
+
+\figref{fig:highlighted_rects_json}より，idキーに対応する値が4である矩形領域座標は，左上頂点のxy座標が(275, 817)であり，幅と高さがそれぞれ733，86，ラベルが"string"である．
+同様に，idキーに対応する値が5である矩形領域座標は，左上頂点のxy座標が(1016, 817)であり，幅と高さがそれぞれ292，86，ラベルが"number"である．
+\figref{fig:highlighted_rects_image}にある4番，および，5番の矩形領域のラベルはそれぞれ，"string", "number"である．
+\figref{fig:highlighted_rects_image}より，画像内に描画した矩形領域の番号のうち，4番の矩形領域は「品名」を記入する欄であり，5番の矩形領域は「数量」を記入する欄である．
+各矩形領域のラベルについて，「品名」は文字列(string)，「数量」は数値(number) がそれぞれ正しいラベルであるため，これら2つの矩形領域について，正しいラベルを割り付けていることを確認できた．
+他の矩形領域に対しても，一部を除き，正しいラベルを割り付けたことを確認した．
+領域座標について，他の矩形領域に対しても，矩形領域座標を正しく取得していることを確認した．
+
+同様に，下線部領域についても，取得した領域座標とラベルが正しいことを確認した．
+
+% 6_discussion
+\section{考察}
+
+本章では，評価実験を行い，開発したツールの有用性を評価する．
+また，開発したツールと先行研究を比較する．
+
+% 6.1
+\subsection{評価実験}
+
+開発したツールの有用性を評価するため，開発したツールを既存の電子フォーム作成ツールに適用し，評価実験を行う．
+適用する電子フォーム作成ツールは，帳票の画像を背景として，記入欄をGUIツールで配置することによって，電子フォームの作成を支援するWebアプリケーションである．
+開発したツールを適用することで，出力であるJSONファイルを参照し，記入欄を自動で配置する．
+
+実験の対象とした2つの帳票の画像を，\figref{fig:form_image_A}，および，\figref{fig:form_image_B}に示す．
+
+% 縦幅がちょっとズレていたので，高さを揃えるためにheightを指定しています．
+\begin{figure}[t]
+	\centering
+	\begin{minipage}[t]{0.5\columnwidth}
+		\centering
+		\fbox{
+			\includegraphics[height=5cm,keepaspectratio]{images/06_discussion/form_image_A.jpg}
+		}
+		\caption{帳票画像A}
+		\ecaption{Form image A}
+		\label{fig:form_image_A}
+	\end{minipage}%
+	\begin{minipage}[t]{0.5\columnwidth}
+		\centering
+		\includegraphics[height=5cm,keepaspectratio]{images/06_discussion/form_image_B.jpg}
+		\caption{帳票画像B}
+		\ecaption{Form image B}
+		\label{fig:form_image_B}
+	\end{minipage}
+\end{figure}
+
+\figref{fig:form_image_A}は，電子文書の画像であり，\figref{fig:form_image_B}は，電子化文書の画像である．
+以降，\figref{fig:form_image_A}の画像を，帳票画像A，\figref{fig:form_image_B}の画像を，帳票画像Bと呼ぶ．
+なお，帳票画像内に存在する記入欄の数は，それぞれ帳票画像Aに77個，帳票画像Bに49個である．
+
+評価実験は，宮崎大学の学生6名を対象として行う．
+実験で計測する3つの時間を，以下に示す．
+
+\begin{itemize}
+	\item 実行時間 \\
+	プログラムの動作開始から終了までにかかる時間
+	\item 配置時間 \\
+	全ての記入欄を適切に配置するまでにかかる時間
+	\item 合計時間 \\
+	実行時間と配置時間の合計
+\end{itemize}
+
+被験者が記入欄を配置するにあたり，以下の2つのケースがある．
+
+\begin{itemize}
+	\item ケース$\alpha$ \\
+	GUIツールのみを用いて記入欄を配置する．
+	\item ケース$\beta$ \\
+	GUIツールに開発したツールを適用し，必要に応じてツールが自動で配置した記入欄を修正する．
+\end{itemize}
+
+実験にあたり，被験者6名を2つのグループに分ける．
+まず，帳票画像Aに対して，一方のグループをケース$\alpha$，他方のグループをケース$\beta$として実験を行う．
+次に，帳票画像Bに対して，両グループの担当ケースを入れ替えて実験を行う．
+
+評価実験の手順を，以下に示す．
+
+\begin{enumerate}
+	\item 実験者は，実行時間の計測を開始し，開発したツールを実行する．
+	\item 実験者は，開発したツールがJSONファイルと領域強調画像の出力を確認し，実行時間の計測を終了する．
+	\item 実験者は，被験者に対して，実験対象の帳票画像と電子フォーム作成ツールの操作方法を説明する．
+	\item 実験者は，配置時間の計測を開始し，被験者は，各ケースに応じた配置方法で記入欄を配置する．
+	\item 実験者は，被験者が全ての記入欄を正しく配置したことを確認し，配置時間の計測を終了する．
+\end{enumerate}
+
+\begin{table}[t]
+	\centering
+	\caption{被験者が電子フォーム内に記入欄を配置するまでにかかった各計測時間の平均（分:秒）}
+	\ecaption{The average of measurement times it took the participants to place fill-in fields in electronic form (min:sec).}
+	\label{tab:measurement_times}
+	\begin{tabular}{clllll}
+		\hline
+		\multirow{2}{*}{計測時間の平均} & & \multicolumn{2}{c}{帳票画像A} & \multicolumn{2}{c}{帳票画像B} \\
+		\cline{3-6} & & ケース$\alpha$ & ケース$\beta$ & ケース$\alpha$ & ケース$\beta$ \\
+		\hline \hline
+		% 実行時間 & & -- & 0:08.48 & 0:10.55 & -- \\
+		% 配置時間 & & 9:09.48 & 4:36.22 & 4:29.43 & 6:26.91 \\
+		% 合計時間 & & 9:09.48 & \textbf{4:44.70} & \textbf{4:39.98} & 6:26.91 \\
+		実行時間 & & -- & 0:08.5 & -- & 0:10.5 \\
+		配置時間 & & 9:09.4 & 4:36.2 & 6:26.9 & 4:29.4 \\
+		合計時間 & & 9:09.4 & \textbf{4:44.7} & 6:26.9 & \textbf{4:39.9} \\
+		\hline
+	\end{tabular}
+\end{table}
+
+各帳票画像における各計測時間の平均を，\tabref{tab:measurement_times}に示す．
+\tabref{tab:measurement_times}より，帳票画像Aについて約4分25秒（約48.2\%），帳票画像Bについて約1分47秒（約27.6\%）の時間を削減したことがわかる．
+これは，開発したツールが電子フォーム内に記入欄を配置するまでにかかる時間を削減できることを示している．
+
+% 6.2
+\subsection{先行研究との比較}
+
+先行研究のうち，同じ画像ベースの手法を用いているYuan氏らの手法\cite{yuan}と比較する．
+帳票画像A，および，帳票画像Bに対して，実行時間と精度を比較する．
+
+速度について，Yuan氏らの手法の実行時間を計測し，開発したツールの実行時間と比較し，評価する．
+
+精度について，適合率と再現率を計測，および，比較し，取得した各領域座標の位置とラベルの正確さを評価する．
+適合率，および，再現率を算出する式を，以下に示す．
+
+\begin{displaymath}
+\text{適合率} = \frac{\text{正しく検出した記入欄の数}}{\text{出力した領域座標の数}}
+\end{displaymath}
+
+\begin{displaymath}
+\text{再現率} = \frac{\text{正しく検出した記入欄の数}}{\text{帳票画像内にある記入欄の数}}
+\end{displaymath}
+
+% 6.2.1
+\subsubsection{実行時間の比較}
+
+帳票画像A，Bについて，Yuan氏らの手法と開発したツールの実行時間を比較した結果を，\tabref{tab:execution_time_comparison}に示す．
+なお，\tabref{tab:execution_time_comparison}で示すそれぞれの時間は，「領域座標取得までの実行時間 （プログラム全体の実行時間）」の形で示す．
+
+\begin{table}[t]
+	\centering
+	\caption{Yuan氏らの手法と開発したツールの実行時間の比較（秒）}
+	\ecaption{Execution time comparison between \\ Yuan's method and the developed tool (sec).}
+	\label{tab:execution_time_comparison}
+	\begin{tabular}{cll}
+		\hline
+		帳票画像 & Yuan氏らの手法 & 開発したツール \\
+		\hline \hline
+		帳票画像A & 0.08(5.85) & 0.62(8.48) \\
+		帳票画像B & 0.14(0.14) & 1.56(10.55) \\
+		\hline
+	\end{tabular}
+\end{table}
+
+\tabref{tab:execution_time_comparison}より，開発したツールはYuan氏らの手法と比較して，2つの帳票画像について，実行時間が長い．
+これは，開発したツールが下線部領域の取得や，取得した水平直線のうち，矩形の一部であるものを除外する処理，領域強調画像の出力に時間を要するためであると考察する．
+
+% 6.2.2
+\subsubsection{精度の比較}
+
+帳票画像A，Bについて，Yuan氏らの手法と開発したツールの精度を比較した結果を，\tabref{tab:accuracy_comparison}に示す．
+なお，Yuan氏らの手法はラベルを割り付ける機能がないため，\tabref{tab:accuracy_comparison}における開発したツールの適合率と再現率は，「ラベルの間違いを考慮しない評価指標 （ラベルの間違いを考慮した評価指標）」の形で示す．
+
+\begin{table*}[t]
+	\centering
+	\caption{Yuan氏らの手法と開発したツールの精度比較（\%）}
+	\ecaption{Accuracy comparison between Yuan's method and the developed tool.}
+	\label{tab:accuracy_comparison}
+	\begin{tabular}{cllll}
+		\hline
+		\multirow{2}{*}{評価指標} & \multicolumn{2}{c}{帳票画像A} & \multicolumn{2}{c}{帳票画像B} \\
+		\cline{2-5} & Yuan氏らの手法 & 開発したツール & Yuan氏らの手法 & 開発したツール \\
+		\hline \hline
+		適合率 & 81.48 & \textbf{87.80（87.80）} & 検出なし & \textbf{84.00（66.00）} \\
+		再現率 & 85.71 & \textbf{93.51（93.51）} & 検出なし & \textbf{83.67（67.35）} \\
+		\hline
+	\end{tabular}
+\end{table*}
+
+\tabref{tab:accuracy_comparison}より，帳票画像Aについて，開発したツールはYuan氏らの手法と比較して，適合率，再現率がともに高いことがわかる．
+Yuan氏らの手法における再現率が，開発したツールにおける結果よりも低い理由として，Yuan氏らの手法は矩形のみを検出し，下線部の記入欄は検出できないためであると考察する．
+
+また，帳票画像Bについて，Yuan氏らの手法では，矩形を検出できなかった．
+その理由は，電子化文書の画像を入力の対象としていないためであると考察する．
+Yuan氏らの手法では，矩形取得のための二値化処理における閾値を220に固定しており，白黒でない画像を適切に二値化できないことが原因であると考察する．
+さらに，帳票画像Bにおいて，開発したツールにおけるラベルの間違いを考慮した再現率と適合率は，ラベルの間違いを考慮しない場合よりも低いことがわかる．
+これは，\figref{fig:form_image_B}中の「品目」という文字を「日目」と誤って文字取得し，日付として属性を推測したことで，「品目」の列にある9個の記入欄に日付のラベルを誤って割り付けたためである．
+
+\tabref{tab:execution_time_comparison}，および，\tabref{tab:accuracy_comparison}より，Yuan氏らの手法と比較して，開発したツールは帳票画像にある記入欄を自動検出する点で優れていることがわかる．
+
+% 7_conclusion
+\section{まとめ}
+
+本研究は，電子フォーム作成にかかる時間の削減を目的として，記入欄自動検出およびラベル割付ツールを開発した．
+開発したツールの出力である領域座標とラベルの精度を確認するため，開発したツールと先行研究の手法における，それぞれの適合率と再現率について考察した．
+開発したツールは，先行研究と比較して，精度の点で優れていることを確認した．
+
+また，開発したツールの有用性を評価するため，既存の電子フォーム作成ツールを用いて，記入欄を配置するまでにかかる時間を計測する実験を行った．
+2枚の帳票画像について，開発したツールを適用した場合と，GUIツールのみを用いた場合とを比較して，それぞれ平均で帳票画像Aについて約4分25秒（約48.2\%），帳票画像Bについて約1分47秒（約27.6\%）短いことがわかった．
+評価実験から，開発したツールは，電子フォーム内に記入欄を配置するまでにかかる時間を削減できることを確認した．
+
+以上のことから，本研究で開発したツールは，電子フォーム作成にかかる時間の削減に有用であると言える．
+
+今後の課題を，以下に示す．
+
+\begin{itemize}
+	\item 色がついた帳票を入力対象とした際の記入欄の認識精度向上
+	\item 記入欄と記入内容を示す欄の区別
+	\item 取得した記入欄への記入内容の紐付け
+\end{itemize}
+
+% \begin{biography}
+% \profile{n}{木村 優哉}{2001年生．2024年宮崎大学工学部情報システム工学科卒業．
+% 同年宮崎大学大学院工学研究科工学専攻先端情報コース修士課程入学．
+% }
+%
+% \profile{h,L}{学会 次郎}{1950年生．1974年架空大学大学院修士課程修了．
+% 1987年同博士課程修了．工学博士．1977年架空大学助手．1992年情報処理大学助
+% 教授．1987年同大教授．2000年から情報処理学会顧問．オンライン出版の研究
+% に従事．2010年情報処理記念賞受賞．情報処理学会理事．電子情報通信学会，
+% IEEE，IEEE-CS，ACM 各会員．}
+% \end{biography}
+
+% 文献リスト
+\bibliographystyle{ipsjunsrt}
+\bibliography{bib_EIP109_kimura}
+
+\end{document}


### PR DESCRIPTION
src 内に IPSJ 環境として配布されているテンプレートのファイル群をそのまま配置することで、IPSJ環境の論文をPDFとして出力できる機能を追加した。

また、句読点ではなくカンマとピリオドが指定されているため、句読点をカンマとピリオドに変換するコマンドも追加。